### PR TITLE
fetch full repo on release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,6 +15,7 @@ jobs:
       - name: Caching dependencies
         uses: actions/cache@v2
         with:
+          fetch-depth: 0
           path: |
             ~/.sbt
             ~/.ivy2


### PR DESCRIPTION
I forgot a little detail in #8 :
For sbt to be able to configure a project version from the latest git tag, the full git history needs to be available.
By default only the current commit is checked out in the github action. `fetch-depth: 0` does a full checkout of the repository, including tags.

Based on this commit I will be able to publish a new release (`v0.2.0`) that supports the `--version` parameter and does not just report `version 0.0.0-[...]`

See an example release of this commit here: https://github.com/jothepro/djinni-generator-1/releases/tag/v0.12.0