### PR TITLE
add const method in +c interface integration test

### DIFF
--- a/src/it/resources/expected/my_cpp_interface/cpp/my_cpp_interface.hpp
+++ b/src/it/resources/expected/my_cpp_interface/cpp/my_cpp_interface.hpp
@@ -17,5 +17,7 @@ public:
 
     virtual int32_t method_returning_some_type(const std::string & key) = 0;
 
+    virtual int32_t method_changing_nothing() const = 0;
+
     static int32_t get_version();
 };

--- a/src/it/resources/expected/my_cpp_interface/java/MyCppInterface.java
+++ b/src/it/resources/expected/my_cpp_interface/java/MyCppInterface.java
@@ -13,6 +13,8 @@ public abstract class MyCppInterface {
 
     public abstract int methodReturningSomeType(String key);
 
+    public abstract int methodChangingNothing();
+
     public static int getVersion()
     {
         return CppProxy.getVersion();
@@ -56,6 +58,14 @@ public abstract class MyCppInterface {
             return native_methodReturningSomeType(this.nativeRef, key);
         }
         private native int native_methodReturningSomeType(long _nativeRef, String key);
+
+        @Override
+        public int methodChangingNothing()
+        {
+            assert !this.destroyed.get() : "trying to use a destroyed object";
+            return native_methodChangingNothing(this.nativeRef);
+        }
+        private native int native_methodChangingNothing(long _nativeRef);
 
         public static native int getVersion();
     }

--- a/src/it/resources/expected/my_cpp_interface/jni/my_cpp_interface.cpp
+++ b/src/it/resources/expected/my_cpp_interface/jni/my_cpp_interface.cpp
@@ -38,6 +38,16 @@ CJNIEXPORT jint JNICALL Java_djinni_it_MyCppInterface_00024CppProxy_native_1meth
     } JNI_TRANSLATE_EXCEPTIONS_RETURN(jniEnv, 0 /* value doesn't matter */)
 }
 
+CJNIEXPORT jint JNICALL Java_djinni_it_MyCppInterface_00024CppProxy_native_1methodChangingNothing(JNIEnv* jniEnv, jobject /*this*/, jlong nativeRef)
+{
+    try {
+        DJINNI_FUNCTION_PROLOGUE1(jniEnv, nativeRef);
+        const auto& ref = ::djinni::objectFromHandleAddress<::MyCppInterface>(nativeRef);
+        auto r = ref->method_changing_nothing();
+        return ::djinni::release(::djinni::I32::fromCpp(jniEnv, r));
+    } JNI_TRANSLATE_EXCEPTIONS_RETURN(jniEnv, 0 /* value doesn't matter */)
+}
+
 CJNIEXPORT jint JNICALL Java_djinni_it_MyCppInterface_00024CppProxy_getVersion(JNIEnv* jniEnv, jobject /*this*/)
 {
     try {

--- a/src/it/resources/expected/my_cpp_interface/objc/ITMyCppInterface.h
+++ b/src/it/resources/expected/my_cpp_interface/objc/ITMyCppInterface.h
@@ -12,6 +12,8 @@ extern int32_t const ITMyCppInterfaceVersion;
 
 - (int32_t)methodReturningSomeType:(nonnull NSString *)key;
 
+- (int32_t)methodChangingNothing;
+
 + (int32_t)getVersion;
 
 @end

--- a/src/it/resources/expected/my_cpp_interface/objcpp/ITMyCppInterface+Private.mm
+++ b/src/it/resources/expected/my_cpp_interface/objcpp/ITMyCppInterface+Private.mm
@@ -43,6 +43,13 @@ static_assert(__has_feature(objc_arc), "Djinni requires ARC to be enabled for th
     } DJINNI_TRANSLATE_EXCEPTIONS()
 }
 
+- (int32_t)methodChangingNothing {
+    try {
+        auto objcpp_result_ = _cppRefHandle.get()->method_changing_nothing();
+        return ::djinni::I32::fromCpp(objcpp_result_);
+    } DJINNI_TRANSLATE_EXCEPTIONS()
+}
+
 + (int32_t)getVersion {
     try {
         auto objcpp_result_ = ::MyCppInterface::get_version();

--- a/src/it/resources/my_cpp_interface.djinni
+++ b/src/it/resources/my_cpp_interface.djinni
@@ -1,6 +1,7 @@
 my_cpp_interface = interface +c {
   method_returning_nothing(value: i32);
   method_returning_some_type(key: string): i32;
+  const method_changing_nothing(): i32;
   static get_version(): i32;
 
   # Interfaces can also have constants


### PR DESCRIPTION
I added a const method to the +c interface because it was missing in the integration testing code.
see https://github.com/cross-language-cpp/djinni-intellij-plugin/pull/19