### PR TITLE
Initial doc of default values for various id_styles

### DIFF
--- a/docs/cli-usage.md
+++ b/docs/cli-usage.md
@@ -190,5 +190,42 @@ The best way to find out how that works is playing around with different values 
 
 !!! note
 
-    Some identifiers do have text transformation enabled by default. 
+    Some identifiers do have text transformation enabled by default.
     Nevertheless make sure to **explicitly set** text transformation styles if you need them! All text transformation may be disabled by default in a future release of the generator.
+
+### Default Identifier Style settings
+(Please note that this list is work in progress)
+#### C++
+
+| Argument | Default  |
+| -------- | -------- |
+| `--ident-cpp-enum` | FooBar |
+| `--ident-cpp-field` | foo_bar |
+| `--ident-cpp-method` | foo_bar |
+| `--ident-cpp-type` | FooBar |
+| `--ident-cpp-enum-type` | FOO_BAR |
+| `--ident-cpp-type-param` | fooBar |
+| `--ident-cpp-local` | foo_bar |
+| `--ident-cpp-file` | - |
+
+#### Java
+
+| Argument | Default  |
+| -------- | -------- |
+| `--ident-java-enum` | FOO_BAR |
+| `--ident-java-field` | fooBar |
+| `--ident-java-type` | FooBar |
+| `--ident-jni-class` | - |
+| `--ident-jni-file` | - |
+
+#### Objective C
+
+| Argument | Default      |
+| -------- | -------- |
+| `--ident-objc-enum` | FooBar |
+| `--ident-objc-field` | fooBar |
+| `--ident-objc-method` | fooBar |
+| `--ident-objc-type` | FooBar |
+| `--ident-objc-type-param` | FooBar |
+| `--ident-objc-local` | fooBar |
+| `--ident-objc-file` | - |


### PR DESCRIPTION
Please note that I have not checked all for correctness
but I thought it is better to have something than nothing, and fix them on the fly if required.

It is not always possible the read the style from the code, it seems there are more settings in the code than options, 
see here, and some lines below how it works (but there might be other conversion in the code also) 
https://github.com/cross-language-cpp/djinni-generator/blob/8d0d18c6a5297bc999c9dafedbff8438a6162a23/src/main/scala/djinni/generator.scala#L94

So some things might needed to be figured out by change the code, generate from idl and check the result, what is time intensive.
It might also turn out that additional command line args are required to apply some conversions that are now only hardcoded available.
We will have to figure out that over time.


