### PR TITLE
update sbt to 1.4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ project/metals.sbt
 
 # for personal trials / tests that shall be ignored but stay on your disk
 ztest/
+
+.bsp/

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.3.13
+sbt.version=1.4.7


### PR DESCRIPTION
This updates sbt to 1.4, which enables use of `sbtn`, the experimental
thing client to sbt server also built with graal. This allows entering
the sbt shell locally very quickly, since you only wait once for the
initial build to load. You can also quickly run commands like `sbtn
test` without fearing that it will take an eternity to start. This makes
sbt feel more like bazel or cmake.