### PR TITLE
Use named parameters for better readability

### DIFF
--- a/src/main/scala/djinni/generator.scala
+++ b/src/main/scala/djinni/generator.scala
@@ -116,9 +116,15 @@ package object generatorTools {
     val underCaps = (s: String) => s.toUpperCase
     val prefix = (prefix: String, suffix: IdentConverter) => (s: String) => prefix + suffix(s)
 
-    val javaDefault = JavaIdentStyle(camelUpper, camelUpper, camelLower, camelLower, camelLower, underCaps, underCaps)
-    val cppDefault = CppIdentStyle(camelUpper, camelUpper, camelUpper, underLower, underLower, underLower, underCaps, underCaps)
-    val objcDefault = ObjcIdentStyle(camelUpper, camelUpper, camelLower, camelLower, camelLower, camelUpper, camelUpper)
+    val javaDefault = JavaIdentStyle(ty = camelUpper, typeParam = camelUpper,
+                                     method = camelLower, field = camelLower, local = camelLower,
+                                     enum = underCaps, const = underCaps)
+    val cppDefault = CppIdentStyle(ty = camelUpper, enumType = camelUpper, typeParam = camelUpper,
+                                   method = underLower, field = underLower, local = underLower,
+                                   enum = underCaps, const = underCaps)
+    val objcDefault = ObjcIdentStyle(ty = camelUpper, typeParam = camelUpper,
+                                     method = camelLower, field = camelLower, local = camelLower,
+                                     enum = camelUpper, const = camelUpper)
 
     val styles = Map(
       "FooBar" -> camelUpper,


### PR DESCRIPTION
Added named parameters for the ident styles to help identifying what goes where. I also formatted them similarly to how they were defined (3 lines each), preserving the original position of each param.