### PR TITLE
Skip Obj-C code generation if output folder was not provided

### DIFF
--- a/src/main/scala/djinni/generator.scala
+++ b/src/main/scala/djinni/generator.scala
@@ -227,10 +227,12 @@ package object generatorTools {
         }
         new ObjcppGenerator(spec).generate(idl)
       }
-      if (spec.objcSwiftBridgingHeaderWriter.isDefined) {
-        SwiftBridgingHeaderGenerator.writeAutogenerationWarning(spec.objcSwiftBridgingHeaderName.get, spec.objcSwiftBridgingHeaderWriter.get)
-        SwiftBridgingHeaderGenerator.writeBridgingVars(spec.objcSwiftBridgingHeaderName.get, spec.objcSwiftBridgingHeaderWriter.get)
-        new SwiftBridgingHeaderGenerator(spec).generate(idl)
+      if (!spec.skipGeneration) {
+        if (spec.objcSwiftBridgingHeaderWriter.isDefined) {
+          SwiftBridgingHeaderGenerator.writeAutogenerationWarning(spec.objcSwiftBridgingHeaderName.get, spec.objcSwiftBridgingHeaderWriter.get)
+          SwiftBridgingHeaderGenerator.writeBridgingVars(spec.objcSwiftBridgingHeaderName.get, spec.objcSwiftBridgingHeaderWriter.get)
+          new SwiftBridgingHeaderGenerator(spec).generate(idl)
+        }
       }
       if (spec.yamlOutFolder.isDefined) {
         if (!spec.skipGeneration) {

--- a/src/main/scala/djinni/generator.scala
+++ b/src/main/scala/djinni/generator.scala
@@ -212,12 +212,12 @@ package object generatorTools {
         }
         new JNIGenerator(spec).generate(idl)
       }
-      if (!spec.skipGeneration) {
-        if (spec.objcOutFolder.isDefined) {
+      if (spec.objcOutFolder.isDefined) {
+        if (!spec.skipGeneration) {
           createFolder("Objective-C", spec.objcOutFolder.get)
-        }
-        if (spec.objcHeaderOutFolder.isDefined) {
-          createFolder("Objective-C header", spec.objcHeaderOutFolder.get)
+          if (spec.objcHeaderOutFolder.isDefined) {
+            createFolder("Objective-C header", spec.objcHeaderOutFolder.get)
+          }
         }
         new ObjcGenerator(spec).generate(idl)
       }

--- a/src/main/scala/djinni/generator.scala
+++ b/src/main/scala/djinni/generator.scala
@@ -116,15 +116,9 @@ package object generatorTools {
     val underCaps = (s: String) => s.toUpperCase
     val prefix = (prefix: String, suffix: IdentConverter) => (s: String) => prefix + suffix(s)
 
-    val javaDefault = JavaIdentStyle(ty = camelUpper, typeParam = camelUpper,
-                                     method = camelLower, field = camelLower, local = camelLower,
-                                     enum = underCaps, const = underCaps)
-    val cppDefault = CppIdentStyle(ty = camelUpper, enumType = camelUpper, typeParam = camelUpper,
-                                   method = underLower, field = underLower, local = underLower,
-                                   enum = underCaps, const = underCaps)
-    val objcDefault = ObjcIdentStyle(ty = camelUpper, typeParam = camelUpper,
-                                     method = camelLower, field = camelLower, local = camelLower,
-                                     enum = camelUpper, const = camelUpper)
+    val javaDefault = JavaIdentStyle(camelUpper, camelUpper, camelLower, camelLower, camelLower, underCaps, underCaps)
+    val cppDefault = CppIdentStyle(camelUpper, camelUpper, camelUpper, underLower, underLower, underLower, underCaps, underCaps)
+    val objcDefault = ObjcIdentStyle(camelUpper, camelUpper, camelLower, camelLower, camelLower, camelUpper, camelUpper)
 
     val styles = Map(
       "FooBar" -> camelUpper,

--- a/src/main/scala/djinni/generator.scala
+++ b/src/main/scala/djinni/generator.scala
@@ -116,9 +116,15 @@ package object generatorTools {
     val underCaps = (s: String) => s.toUpperCase
     val prefix = (prefix: String, suffix: IdentConverter) => (s: String) => prefix + suffix(s)
 
-    val javaDefault = JavaIdentStyle(camelUpper, camelUpper, camelLower, camelLower, camelLower, underCaps, underCaps)
-    val cppDefault = CppIdentStyle(camelUpper, camelUpper, camelUpper, underLower, underLower, underLower, underCaps, underCaps)
-    val objcDefault = ObjcIdentStyle(camelUpper, camelUpper, camelLower, camelLower, camelLower, camelUpper, camelUpper)
+    val javaDefault = JavaIdentStyle(ty = camelUpper, typeParam = camelUpper,
+                                     method = camelLower, field = camelLower, local = camelLower,
+                                     enum = underCaps, const = underCaps)
+    val cppDefault = CppIdentStyle(ty = camelUpper, enumType = camelUpper, typeParam = camelUpper,
+                                   method = underLower, field = underLower, local = underLower,
+                                   enum = underCaps, const = underCaps)
+    val objcDefault = ObjcIdentStyle(ty = camelUpper, typeParam = camelUpper,
+                                     method = camelLower, field = camelLower, local = camelLower,
+                                     enum = camelUpper, const = camelUpper)
 
     val styles = Map(
       "FooBar" -> camelUpper,


### PR DESCRIPTION
Fixes the following exception when issuing a Djinni command to generate code other than Obj-C:
```Exception in thread "main" java.util.NoSuchElementException: None.get
        at scala.None$.get(Option.scala:529)
        at scala.None$.get(Option.scala:527)
        at djinni.ObjcGenerator.writeObjcFile(ObjcGenerator.scala:412)
        at djinni.ObjcGenerator.generateInterface(ObjcGenerator.scala:104)
        at djinni.Generator.$anonfun$generate$2(generator.scala:363)
        at djinni.Generator.$anonfun$generate$2$adapted(generator.scala:358)
        at scala.collection.LinearSeqOptimized.foreach(LinearSeqOptimized.scala:75)
        at scala.collection.LinearSeqOptimized.foreach$(LinearSeqOptimized.scala:72)
        at scala.collection.mutable.MutableList.foreach(MutableList.scala:33)
        at djinni.Generator.generate(generator.scala:358)
        at djinni.generatorTools.package$.generate(generator.scala:222)
        at djinni.Main$.main(Main.scala:374)
        at djinni.Main.main(Main.scala)
```