### PR TITLE
Remove any hardcoded references to std::experimental

### DIFF
--- a/src/it/resources/expected/all_datatypes/cwrapper/dh__all_datatypes.cpp
+++ b/src/it/resources/expected/all_datatypes/cwrapper/dh__all_datatypes.cpp
@@ -170,7 +170,7 @@ djinni::Handle<DjinniRecordHandle> DjinniAllDatatypes::fromCpp(const ::AllDataty
 }
 
 djinni::Handle<DjinniOptionalRecordHandle> DjinniAllDatatypes::fromCpp(std::optional<::AllDatatypes> dc) {
-    if (dc == std::experimental::nullopt) {
+    if (!dc) {
         return nullptr;
     }
     return djinni::optionals::toOptionalHandle(DjinniAllDatatypes::fromCpp(std::move(* dc)), optional_all_datatypes___delete);
@@ -180,6 +180,6 @@ std::optional<::AllDatatypes>DjinniAllDatatypes::toCpp(djinni::Handle<DjinniOpti
      if (dh) {
         return std::optional<::AllDatatypes>(DjinniAllDatatypes::toCpp(djinni::optionals::fromOptionalHandle(std::move(dh), all_datatypes___delete)));
     }
-    return std::experimental::nullopt;
+    return {};
 }
 

--- a/src/it/resources/expected/all_datatypes/cwrapper/dh__list_bool.cpp
+++ b/src/it/resources/expected/all_datatypes/cwrapper/dh__list_bool.cpp
@@ -72,7 +72,7 @@ std::vector<bool> DjinniListBool::toCpp(djinni::Handle<DjinniObjectHandle> dh) {
 }
 
 djinni::Handle<DjinniOptionalObjectHandle> DjinniListBool::fromCpp(std::optional<std::vector<bool>> dc) {
-    if (dc == std::experimental::nullopt) {
+    if (!dc) {
         return nullptr;
     }
     return djinni::optionals::toOptionalHandle(DjinniListBool::fromCpp(std::move(* dc)), optional_list_bool___delete);
@@ -82,6 +82,6 @@ std::optional<std::vector<bool>>DjinniListBool::toCpp(djinni::Handle<DjinniOptio
      if (dh) {
         return std::optional<std::vector<bool>>(DjinniListBool::toCpp(djinni::optionals::fromOptionalHandle(std::move(dh), list_bool___delete)));
     }
-    return std::experimental::nullopt;
+    return {};
 }
 

--- a/src/it/resources/expected/all_datatypes/cwrapper/dh__map_int8_t_bool.cpp
+++ b/src/it/resources/expected/all_datatypes/cwrapper/dh__map_int8_t_bool.cpp
@@ -80,7 +80,7 @@ std::unordered_map<int8_t, bool> DjinniMapInt8TBool::toCpp(djinni::Handle<Djinni
 }
 
 djinni::Handle<DjinniOptionalObjectHandle> DjinniMapInt8TBool::fromCpp(std::optional<std::unordered_map<int8_t, bool>> dc) {
-    if (dc == std::experimental::nullopt) {
+    if (!dc) {
         return nullptr;
     }
     return djinni::optionals::toOptionalHandle(DjinniMapInt8TBool::fromCpp(std::move(* dc)), optional_map_int8_t_bool___delete);
@@ -90,6 +90,6 @@ std::optional<std::unordered_map<int8_t, bool>>DjinniMapInt8TBool::toCpp(djinni:
      if (dh) {
         return std::optional<std::unordered_map<int8_t, bool>>(DjinniMapInt8TBool::toCpp(djinni::optionals::fromOptionalHandle(std::move(dh), map_int8_t_bool___delete)));
     }
-    return std::experimental::nullopt;
+    return {};
 }
 

--- a/src/it/resources/expected/all_datatypes/cwrapper/dh__set_bool.cpp
+++ b/src/it/resources/expected/all_datatypes/cwrapper/dh__set_bool.cpp
@@ -71,7 +71,7 @@ std::unordered_set<bool> DjinniSetBool::toCpp(djinni::Handle<DjinniObjectHandle>
 }
 
 djinni::Handle<DjinniOptionalObjectHandle> DjinniSetBool::fromCpp(std::optional<std::unordered_set<bool>> dc) {
-    if (dc == std::experimental::nullopt) {
+    if (!dc) {
         return nullptr;
     }
     return djinni::optionals::toOptionalHandle(DjinniSetBool::fromCpp(std::move(* dc)), optional_set_bool___delete);
@@ -81,6 +81,6 @@ std::optional<std::unordered_set<bool>>DjinniSetBool::toCpp(djinni::Handle<Djinn
      if (dh) {
         return std::optional<std::unordered_set<bool>>(DjinniSetBool::toCpp(djinni::optionals::fromOptionalHandle(std::move(dh), set_bool___delete)));
     }
-    return std::experimental::nullopt;
+    return {};
 }
 

--- a/src/it/resources/expected/my_enum/cwrapper/dh__my_enum.cpp
+++ b/src/it/resources/expected/my_enum/cwrapper/dh__my_enum.cpp
@@ -18,7 +18,7 @@ int32_t int32_from_enum_my_enum(::MyEnum e) {
 }
 std::optional<::MyEnum> get_boxed_enum_my_enum_from_int32(int32_t e) {
     if (e == -1) { // to signal null enum
-        return std::experimental::nullopt;
+        return {};
     }
     return std::optional<::MyEnum>(static_cast<::MyEnum>(e));
 }

--- a/src/it/resources/expected/my_flags/cwrapper/dh__my_flags.cpp
+++ b/src/it/resources/expected/my_flags/cwrapper/dh__my_flags.cpp
@@ -18,7 +18,7 @@ int32_t int32_from_enum_my_flags(::MyFlags e) {
 }
 std::optional<::MyFlags> get_boxed_enum_my_flags_from_int32(int32_t e) {
     if (e == -1) { // to signal null enum
-        return std::experimental::nullopt;
+        return {};
     }
     return std::optional<::MyFlags>(static_cast<::MyFlags>(e));
 }

--- a/src/it/resources/expected/my_record/cwrapper/dh__map_string_int32_t.cpp
+++ b/src/it/resources/expected/my_record/cwrapper/dh__map_string_int32_t.cpp
@@ -77,7 +77,7 @@ std::unordered_map<std::string, int32_t> DjinniMapStringInt32T::toCpp(djinni::Ha
 }
 
 djinni::Handle<DjinniOptionalObjectHandle> DjinniMapStringInt32T::fromCpp(std::optional<std::unordered_map<std::string, int32_t>> dc) {
-    if (dc == std::experimental::nullopt) {
+    if (!dc) {
         return nullptr;
     }
     return djinni::optionals::toOptionalHandle(DjinniMapStringInt32T::fromCpp(std::move(* dc)), optional_map_string_int32_t___delete);
@@ -87,6 +87,6 @@ std::optional<std::unordered_map<std::string, int32_t>>DjinniMapStringInt32T::to
      if (dh) {
         return std::optional<std::unordered_map<std::string, int32_t>>(DjinniMapStringInt32T::toCpp(djinni::optionals::fromOptionalHandle(std::move(dh), map_string_int32_t___delete)));
     }
-    return std::experimental::nullopt;
+    return {};
 }
 

--- a/src/it/resources/expected/my_record/cwrapper/dh__my_record.cpp
+++ b/src/it/resources/expected/my_record/cwrapper/dh__my_record.cpp
@@ -80,7 +80,7 @@ djinni::Handle<DjinniRecordHandle> DjinniMyRecord::fromCpp(const ::MyRecord& dr)
 }
 
 djinni::Handle<DjinniOptionalRecordHandle> DjinniMyRecord::fromCpp(std::optional<::MyRecord> dc) {
-    if (dc == std::experimental::nullopt) {
+    if (!dc) {
         return nullptr;
     }
     return djinni::optionals::toOptionalHandle(DjinniMyRecord::fromCpp(std::move(* dc)), optional_my_record___delete);
@@ -90,6 +90,6 @@ std::optional<::MyRecord>DjinniMyRecord::toCpp(djinni::Handle<DjinniOptionalReco
      if (dh) {
         return std::optional<::MyRecord>(DjinniMyRecord::toCpp(djinni::optionals::fromOptionalHandle(std::move(dh), my_record___delete)));
     }
-    return std::experimental::nullopt;
+    return {};
 }
 

--- a/src/it/resources/expected/my_record/cwrapper/dh__set_string.cpp
+++ b/src/it/resources/expected/my_record/cwrapper/dh__set_string.cpp
@@ -68,7 +68,7 @@ std::unordered_set<std::string> DjinniSetString::toCpp(djinni::Handle<DjinniObje
 }
 
 djinni::Handle<DjinniOptionalObjectHandle> DjinniSetString::fromCpp(std::optional<std::unordered_set<std::string>> dc) {
-    if (dc == std::experimental::nullopt) {
+    if (!dc) {
         return nullptr;
     }
     return djinni::optionals::toOptionalHandle(DjinniSetString::fromCpp(std::move(* dc)), optional_set_string___delete);
@@ -78,6 +78,6 @@ std::optional<std::unordered_set<std::string>>DjinniSetString::toCpp(djinni::Han
      if (dh) {
         return std::optional<std::unordered_set<std::string>>(DjinniSetString::toCpp(djinni::optionals::fromOptionalHandle(std::move(dh), set_string___delete)));
     }
-    return std::experimental::nullopt;
+    return {};
 }
 

--- a/src/it/resources/expected/using_custom_datatypes/cwrapper/dh__custom_datatype.cpp
+++ b/src/it/resources/expected/using_custom_datatypes/cwrapper/dh__custom_datatype.cpp
@@ -50,7 +50,7 @@ djinni::Handle<DjinniRecordHandle> DjinniCustomDatatype::fromCpp(const ::CustomD
 }
 
 djinni::Handle<DjinniOptionalRecordHandle> DjinniCustomDatatype::fromCpp(std::optional<::CustomDatatype> dc) {
-    if (dc == std::experimental::nullopt) {
+    if (!dc) {
         return nullptr;
     }
     return djinni::optionals::toOptionalHandle(DjinniCustomDatatype::fromCpp(std::move(* dc)), optional_custom_datatype___delete);
@@ -60,6 +60,6 @@ std::optional<::CustomDatatype>DjinniCustomDatatype::toCpp(djinni::Handle<Djinni
      if (dh) {
         return std::optional<::CustomDatatype>(DjinniCustomDatatype::toCpp(djinni::optionals::fromOptionalHandle(std::move(dh), custom_datatype___delete)));
     }
-    return std::experimental::nullopt;
+    return {};
 }
 

--- a/src/it/resources/expected/using_custom_datatypes/cwrapper/dh__other_record.cpp
+++ b/src/it/resources/expected/using_custom_datatypes/cwrapper/dh__other_record.cpp
@@ -51,7 +51,7 @@ djinni::Handle<DjinniRecordHandle> DjinniOtherRecord::fromCpp(const ::OtherRecor
 }
 
 djinni::Handle<DjinniOptionalRecordHandle> DjinniOtherRecord::fromCpp(std::optional<::OtherRecord> dc) {
-    if (dc == std::experimental::nullopt) {
+    if (!dc) {
         return nullptr;
     }
     return djinni::optionals::toOptionalHandle(DjinniOtherRecord::fromCpp(std::move(* dc)), optional_other_record___delete);
@@ -61,6 +61,6 @@ std::optional<::OtherRecord>DjinniOtherRecord::toCpp(djinni::Handle<DjinniOption
      if (dh) {
         return std::optional<::OtherRecord>(DjinniOtherRecord::toCpp(djinni::optionals::fromOptionalHandle(std::move(dh), other_record___delete)));
     }
-    return std::experimental::nullopt;
+    return {};
 }
 

--- a/src/main/scala/djinni/CWrapperGenerator.scala
+++ b/src/main/scala/djinni/CWrapperGenerator.scala
@@ -332,7 +332,7 @@ class CWrapperGenerator(spec: Spec) extends Generator(spec) {
 
   def writeOptionalContainerFromCpp(optHandle: String, handle: String, retType: String, djinniWrapper: String, deleteMethod: String, w: IndentWriter): Unit = {
     w.wl("djinni::Handle" + t(optHandle) + " " +  djinniWrapper + "::fromCpp" + p( spec.cppOptionalTemplate + t(retType) + " dc") + " {").nested {
-      w.wl("if (dc == std::experimental::nullopt) {").nested {
+      w.wl("if (!dc) {").nested {
         w.wl("return nullptr;")
       }
       w.wl("}")
@@ -348,7 +348,7 @@ class CWrapperGenerator(spec: Spec) extends Generator(spec) {
         w.wl("return " + spec.cppOptionalTemplate + t(retTypeStr) + p(djinniWrapper + "::toCpp" + p("djinni::optionals::fromOptionalHandle(std::move(dh), " + deleteMethod +")")) + ";")
       }
       w.wl("}")
-      w.wl("return std::experimental::nullopt;")
+      w.wl("return {};")
     }
     w.wl("}")
     w.wl
@@ -1178,7 +1178,7 @@ class CWrapperGenerator(spec: Spec) extends Generator(spec) {
       w.wl(spec.cppOptionalTemplate + t(withCppNs(idCpp.enumType(ident.name))) +
             " get_boxed_enum_" + idCpp.method(ident.name) + "_from_int32" + p("int32_t e") + " {").nested {
         w.wl("if (e == -1) { // to signal null enum").nested {
-          w.wl("return std::experimental::nullopt;")
+          w.wl("return {};")
         }
         w.wl("}")
         w.wl("return " + spec.cppOptionalTemplate + t(withCppNs(idCpp.enumType(ident.name))) +


### PR DESCRIPTION
[As mentioned in the Python PR on the support lib](https://github.com/cross-language-cpp/djinni-support-lib/pull/24#discussion_r617139250), there were a few places in the generator where explicit references to `std::experimental` had been left behind. The options presented at that point to solve it were to either hardcode `std::optional`/`std::nullopt` everywhere or use the command-line parameter for the optional type to replace the aforementioned references.

This PR represents a third option, which is to replace the three instances of `std::[experimental::]nullopt` with code that does not specify any type:

- Evaluate the optional type directly in a boolean context (`false` means `!= std::[experimental::]nullopt`)
- Default-construct an `std::[experimental::]optional` object with `{}` (which is equivalent to `std::[experimental::]nullopt`)

This might be an acceptable solution until we decide (or find time) to deal with the `std::[experimental::]optional` situation as a whole.