### PR TITLE
Do not require YAML definitions for a language that is not being generated

### DIFF
--- a/src/it/resources/date_no_cs.djinni
+++ b/src/it/resources/date_no_cs.djinni
@@ -1,0 +1,9 @@
+@extern "date_no_cs.yaml"
+
+date_record = record {
+    created_at: extern_date;
+} deriving(eq, ord, parcelable)
+
+map_date_record = record {
+    dates_by_id: map<string, extern_date>;
+}

--- a/src/it/resources/date_no_cs.yaml
+++ b/src/it/resources/date_no_cs.yaml
@@ -31,4 +31,4 @@ jni:
   typename: jobject
   typeSignature: 'Ljava/util/Date;'
 
-# No C# definition!
+# No C# definitions!

--- a/src/it/resources/date_no_cs.yaml
+++ b/src/it/resources/date_no_cs.yaml
@@ -1,0 +1,34 @@
+# This is an example YAML file mimicking the builtin "date" type as external type
+---
+name: extern_date
+typedef: 'record deriving(eq, ord, parcelable)'
+params: []
+prefix: ''
+cpp:
+  typename: 'std::chrono::system_clock::time_point'
+  header: '<chrono>'
+  byValue: true
+objc:
+  typename: 'NSDate'
+  header: '<Foundation/Foundation.h>'
+  boxed: 'NSDate'
+  pointer: true
+  hash: '(NSUInteger)%s.timeIntervalSinceReferenceDate'
+objcpp:
+  translator: '::djinni::Date'
+  header: '"DJIMarshal+Private.h"'
+java:
+  typename: 'java.util.Date'
+  boxed: 'java.util.Date'
+  reference: true
+  generic: true
+  hash: '%s.hashCode()'
+  writeToParcel: 'out.writeLong(%s.getTime())'
+  readFromParcel: 'new %s(in.readLong())'
+jni:
+  translator: '::djinni::Date'
+  header: '"djinni/jni/Marshal.hpp"'
+  typename: jobject
+  typeSignature: 'Ljava/util/Date;'
+
+# No C# definition!

--- a/src/it/resources/date_no_cs.yaml
+++ b/src/it/resources/date_no_cs.yaml
@@ -9,7 +9,7 @@ cpp:
   header: '<chrono>'
   byValue: true
 objc:
-  typename: 'NSDate'
+  # Key 'typename' missing
   header: '<Foundation/Foundation.h>'
   boxed: 'NSDate'
   pointer: true

--- a/src/it/scala/djinni/GeneratorIntegrationTest.scala
+++ b/src/it/scala/djinni/GeneratorIntegrationTest.scala
@@ -224,8 +224,11 @@ class GeneratorIntegrationTest extends IntegrationTest with GivenWhenThen {
     it("should be able to parse yaml files without all languages defined") {
       val outputPath = "src/it/resources/result/only_yaml_out"
       When("calling the generator with ")
+      a [RuntimeException] should be thrownBy {
+        djinni(s"--idl src/it/resources/date_no_cs.djinni --cppcli-out $outputPath")
+      }
       noException should be thrownBy {
-        djinni(s"--idl src/it/resources/date_no_cs.djinni --yaml-out $outputPath")
+        djinni(s"--idl src/it/resources/date_no_cs.djinni --java-out $outputPath")
       }
     }
   }

--- a/src/it/scala/djinni/GeneratorIntegrationTest.scala
+++ b/src/it/scala/djinni/GeneratorIntegrationTest.scala
@@ -224,12 +224,9 @@ class GeneratorIntegrationTest extends IntegrationTest with GivenWhenThen {
     it("should be able to parse yaml files without all languages defined") {
       val outputPath = "src/it/resources/result/only_yaml_out"
       When("calling the generator with ")
-      a [RuntimeException] should be thrownBy {
-        djinni(s"--idl src/it/resources/date_no_cs.djinni --cppcli-out $outputPath")
-      }
-      noException should be thrownBy {
-        djinni(s"--idl src/it/resources/date_no_cs.djinni --java-out $outputPath")
-      }
+      a [RuntimeException] should be thrownBy djinni(s"--idl src/it/resources/date_no_cs.djinni --cppcli-out $outputPath")
+      a [RuntimeException] should be thrownBy djinni(s"--idl src/it/resources/date_no_cs.djinni --objc-out $outputPath")
+      noException should be thrownBy djinni(s"--idl src/it/resources/date_no_cs.djinni --java-out $outputPath")
     }
   }
 }

--- a/src/it/scala/djinni/GeneratorIntegrationTest.scala
+++ b/src/it/scala/djinni/GeneratorIntegrationTest.scala
@@ -234,7 +234,9 @@ class GeneratorIntegrationTest extends IntegrationTest with GivenWhenThen {
 
     it("should gracefully fail when a required language definition is incomplete") {
       val outputPath = "src/it/resources/result/only_yaml_out"
-      When("calling the generator with ")
+      Given("an IDL file that depends on a YAML type definition that misses a required key in the `objc` definition")
+      When("calling the generator")
+      Then("the generation should fail gracefully if code for Objective-C is generated")
       a [RuntimeException] should be thrownBy djinni(s"--idl src/it/resources/date_no_cs.djinni --objc-out $outputPath")
     }
   }

--- a/src/it/scala/djinni/GeneratorIntegrationTest.scala
+++ b/src/it/scala/djinni/GeneratorIntegrationTest.scala
@@ -225,8 +225,13 @@ class GeneratorIntegrationTest extends IntegrationTest with GivenWhenThen {
       val outputPath = "src/it/resources/result/only_yaml_out"
       When("calling the generator with ")
       a [RuntimeException] should be thrownBy djinni(s"--idl src/it/resources/date_no_cs.djinni --cppcli-out $outputPath")
-      a [RuntimeException] should be thrownBy djinni(s"--idl src/it/resources/date_no_cs.djinni --objc-out $outputPath")
       noException should be thrownBy djinni(s"--idl src/it/resources/date_no_cs.djinni --java-out $outputPath")
+    }
+
+    it("should gracefully fail when a required language definition is incomplete") {
+      val outputPath = "src/it/resources/result/only_yaml_out"
+      When("calling the generator with ")
+      a [RuntimeException] should be thrownBy djinni(s"--idl src/it/resources/date_no_cs.djinni --objc-out $outputPath")
     }
   }
 }

--- a/src/it/scala/djinni/GeneratorIntegrationTest.scala
+++ b/src/it/scala/djinni/GeneratorIntegrationTest.scala
@@ -223,8 +223,12 @@ class GeneratorIntegrationTest extends IntegrationTest with GivenWhenThen {
 
     it("should be able to parse yaml files without all languages defined") {
       val outputPath = "src/it/resources/result/only_yaml_out"
-      When("calling the generator with ")
+      Given("an IDL that depends on a YAML type definition that misses the `cs` key")
+      When("calling the generator  with `--cppcli-out` to generate C# gluecode")
+      Then("the generation should fail gracefully")
       a [RuntimeException] should be thrownBy djinni(s"--idl src/it/resources/date_no_cs.djinni --cppcli-out $outputPath")
+      When("calling the generator with `--java-out` to generate just Java gluecode")
+      Then("the generator should not fail, because the `cs` type definition is not needed")
       noException should be thrownBy djinni(s"--idl src/it/resources/date_no_cs.djinni --java-out $outputPath")
     }
 

--- a/src/it/scala/djinni/GeneratorIntegrationTest.scala
+++ b/src/it/scala/djinni/GeneratorIntegrationTest.scala
@@ -1,7 +1,7 @@
 package djinni
 
 import org.scalatest.GivenWhenThen
-import org.scalatest.Matchers.{convertToAnyShouldWrapper, equal}
+import org.scalatest.Matchers._
 import org.scalatest.prop.TableDrivenPropertyChecks._
 
 class GeneratorIntegrationTest extends IntegrationTest with GivenWhenThen {
@@ -219,6 +219,14 @@ class GeneratorIntegrationTest extends IntegrationTest with GivenWhenThen {
       assertFileExists(s"$outputPath/dh__list_bool.py")
       assertFileExists(s"$outputPath/dh__map_int8_t_bool.py")
       assertFileExists(s"$outputPath/dh__set_bool.py")
+    }
+
+    it("should be able to parse yaml files without all languages defined") {
+      val outputPath = "src/it/resources/result/only_yaml_out"
+      When("calling the generator with ")
+      noException should be thrownBy {
+        djinni(s"--idl src/it/resources/date_no_cs.djinni --yaml-out $outputPath")
+      }
     }
   }
 }

--- a/src/main/scala/djinni/CppCliGenerator.scala
+++ b/src/main/scala/djinni/CppCliGenerator.scala
@@ -158,7 +158,7 @@ class CppCliGenerator(spec: Spec) extends Generator(spec) {
         case p: MPrimitive => "."
         case MOptional => "."
         case MDate => "."
-        case e: MExtern => if (e.cs.reference) "->" else "."
+        case e: MExtern => if (e.cs.reference.get) "->" else "."
         case _ => "->"
       }
     }
@@ -581,11 +581,11 @@ class CppCliGenerator(spec: Spec) extends Generator(spec) {
               case _ => "nullptr"
             }
           case e: MExtern =>
-            if (e.cs.reference) "nullptr" else typeStr + "()"
+            if (e.cs.reference.get) "nullptr" else typeStr + "()"
           case _ => "nullptr"
         }
       case e: MExtern =>
-        if (e.cs.reference) "nullptr" else typeStr + "()"
+        if (e.cs.reference.get) "nullptr" else typeStr + "()"
       case _ => "nullptr"
     }
   }

--- a/src/main/scala/djinni/CppCliMarshal.scala
+++ b/src/main/scala/djinni/CppCliMarshal.scala
@@ -73,7 +73,7 @@ class CppCliMarshal(spec: Spec) extends Marshal(spec) {
       } else {
         List()
       }
-    case e: MExtern => List(ImportRef(e.cs.header))
+    case e: MExtern => List(ImportRef(e.cs.header.get))
     case _ => List()
   }
 
@@ -103,7 +103,7 @@ class CppCliMarshal(spec: Spec) extends Marshal(spec) {
             }
           case MOptional => ""
           case MDate => ""
-          case e: MExtern => if (e.cs.reference) "^" else ""
+          case e: MExtern => if (e.cs.reference.get) "^" else ""
           case _ => "^"
         }
       } else ""
@@ -123,14 +123,14 @@ class CppCliMarshal(spec: Spec) extends Marshal(spec) {
                 case _ => expr(arg)
               }
             case e: MExtern =>
-              if (e.cs.reference) {
+              if (e.cs.reference.get) {
                 expr(arg)
               } else {
                 "System::Nullable" + args
               }
             case _ => expr(arg)
           }
-        case e: MExtern => withNamespace(e.cs.typename)
+        case e: MExtern => withNamespace(e.cs.typename.get)
         case o =>
           val base = o match {
             case p: MPrimitive => p.cppCliName
@@ -156,7 +156,7 @@ class CppCliMarshal(spec: Spec) extends Marshal(spec) {
       case DEnum => withNs(Some("djinni"), s"Enum<${cppMarshal.fqTypename(tm)}, ${fqTypename(tm)}>")
       case _ => withNs(Some(spec.cppCliNamespace.replace(".", "::")), helperClass(d.name))
     }
-    case e: MExtern => e.cs.translator
+    case e: MExtern => e.cs.translator.get
     case o => withNs(Some("djinni"), o match {
       case p: MPrimitive => p.idlName match {
         case "i8" => "I8"

--- a/src/main/scala/djinni/CppMarshal.scala
+++ b/src/main/scala/djinni/CppMarshal.scala
@@ -163,7 +163,7 @@ class CppMarshal(spec: Spec) extends Marshal(spec) {
           case DInterface => s"std::shared_ptr<${withNamespace(idCpp.ty(d.name))}>"
         }
       case e: MExtern => e.defType match {
-        case DInterface => s"std::shared_ptr<${e.cpp.typename}>"
+        case DInterface => s"std::shared_ptr<${e.cpp.typename.get}>"
         case _ => e.cpp.typename.get
       }
       case p: MParam => idCpp.typeParam(p.name)

--- a/src/main/scala/djinni/CppMarshal.scala
+++ b/src/main/scala/djinni/CppMarshal.scala
@@ -95,8 +95,8 @@ class CppMarshal(spec: Spec) extends Marshal(spec) {
     case e: MExtern => e.defType match {
       // Do not forward declare extern types, they might be in arbitrary namespaces.
       // This isn't a problem as extern types cannot cause dependency cycles with types being generated here
-      case DInterface => List(ImportRef("<memory>"), ImportRef(e.cpp.header))
-      case _ => List(ImportRef(e.cpp.header))
+      case DInterface => List(ImportRef("<memory>"), ImportRef(e.cpp.header.get))
+      case _ => List(ImportRef(e.cpp.header.get))
     }
     case p: MParam => List()
   }
@@ -164,7 +164,7 @@ class CppMarshal(spec: Spec) extends Marshal(spec) {
         }
       case e: MExtern => e.defType match {
         case DInterface => s"std::shared_ptr<${e.cpp.typename}>"
-        case _ => e.cpp.typename
+        case _ => e.cpp.typename.get
       }
       case p: MParam => idCpp.typeParam(p.name)
     }
@@ -214,7 +214,7 @@ class CppMarshal(spec: Spec) extends Marshal(spec) {
     case e: MExtern => e.defType match {
       case DInterface => false
       case DEnum => true
-      case DRecord => e.cpp.byValue
+      case DRecord => e.cpp.byValue.get
     }
     case MOptional => byValue(tm.args.head)
     case _ => false

--- a/src/main/scala/djinni/JNIMarshal.scala
+++ b/src/main/scala/djinni/JNIMarshal.scala
@@ -36,7 +36,7 @@ class JNIMarshal(spec: Spec) extends Marshal(spec) {
   def references(m: Meta, exclude: String = ""): Seq[SymbolReference] = m match {
     case o: MOpaque => List(ImportRef(q(spec.jniBaseLibIncludePrefix + "Marshal.hpp")))
     case d: MDef => List(ImportRef(include(d.name)))
-    case e: MExtern => List(ImportRef(e.jni.header))
+    case e: MExtern => List(ImportRef(e.jni.header.get))
     case _ => List()
   }
 
@@ -74,7 +74,7 @@ class JNIMarshal(spec: Spec) extends Marshal(spec) {
       case MSet => "Ljava/util/HashSet;"
       case MMap => "Ljava/util/HashMap;"
     }
-    case e: MExtern => e.jni.typeSignature
+    case e: MExtern => e.jni.typeSignature.get
     case MParam(_) => "Ljava/lang/Object;"
     case d: MDef => d.body match {
       case e: Enum if e.flags => "Ljava/util/EnumSet;"
@@ -88,7 +88,7 @@ class JNIMarshal(spec: Spec) extends Marshal(spec) {
 
   def helperName(tm: MExpr): String = tm.base match {
     case d: MDef => withNs(Some(spec.jniNamespace), helperClass(d.name))
-    case e: MExtern => e.jni.translator
+    case e: MExtern => e.jni.translator.get
     case o => withNs(Some("djinni"), o match {
       case p: MPrimitive => p.idlName match {
         case "i8" => "I8"

--- a/src/main/scala/djinni/JavaGenerator.scala
+++ b/src/main/scala/djinni/JavaGenerator.scala
@@ -362,7 +362,7 @@ class JavaGenerator(spec: Spec) extends Generator(spec) {
                     case _ => throw new AssertionError("Unreachable")
                   }
                   case e: MExtern => e.defType match {
-                    case DRecord => if(e.java.reference) {
+                    case DRecord => if(e.java.reference.get) {
                       w.w(s"this.${idJava.field(f.ident)}.equals(other.${idJava.field(f.ident)})")
                     } else {
                       w.w(s"this.${idJava.field(f.ident)} == other.${idJava.field(f.ident)}")
@@ -403,7 +403,7 @@ class JavaGenerator(spec: Spec) extends Generator(spec) {
                   case _ => throw new AssertionError("Unreachable")
                 }
                 case e: MExtern => e.defType match {
-                  case DRecord => "(" + e.java.hash.format(idJava.field(f.ident)) + ")"
+                  case DRecord => "(" + e.java.hash.get.format(idJava.field(f.ident)) + ")"
                   case DEnum => s"${idJava.field(f.ident)}.hashCode()"
                   case _ => throw new AssertionError("Unreachable")
                 }
@@ -462,7 +462,7 @@ class JavaGenerator(spec: Spec) extends Generator(spec) {
                   case _ => throw new AssertionError("Unreachable")
                 }
                 case e: MExtern => e.defType match {
-                  case DRecord => if(e.java.reference) w.wl(s"tempResult = this.${idJava.field(f.ident)}.compareTo(other.${idJava.field(f.ident)});") else primitiveCompare(f.ident)
+                  case DRecord => if(e.java.reference.get) w.wl(s"tempResult = this.${idJava.field(f.ident)}.compareTo(other.${idJava.field(f.ident)});") else primitiveCompare(f.ident)
                   case DEnum => w.w(s"tempResult = this.${idJava.field(f.ident)}.compareTo(other.${idJava.field(f.ident)});")
                   case _ => throw new AssertionError("Unreachable")
                 }

--- a/src/main/scala/djinni/JavaMarshal.scala
+++ b/src/main/scala/djinni/JavaMarshal.scala
@@ -71,7 +71,7 @@ class JavaMarshal(spec: Spec) extends Marshal(spec) {
         }
       case e: MExtern => e.defType match {
         case DInterface => interfaceNullityAnnotation
-        case DRecord => if(e.java.reference) javaNonnullAnnotation else None
+        case DRecord => if(e.java.reference.get) javaNonnullAnnotation else None
         case DEnum => javaNonnullAnnotation
       }
       case _ => javaNonnullAnnotation
@@ -112,7 +112,7 @@ class JavaMarshal(spec: Spec) extends Marshal(spec) {
             case MOptional => throw new AssertionError("nested optional?")
             case m => f(arg, true)
           }
-        case e: MExtern => (if(needRef) e.java.boxed else e.java.typename) + (if(e.java.generic) args(tm) else "")
+        case e: MExtern => (if(needRef) e.java.boxed else e.java.typename) + (if(e.java.generic.get) args(tm) else "")
         case o =>
           val base = o match {
             case p: MPrimitive => if (needRef) p.jBoxed else p.jName

--- a/src/main/scala/djinni/JavaMarshal.scala
+++ b/src/main/scala/djinni/JavaMarshal.scala
@@ -112,7 +112,7 @@ class JavaMarshal(spec: Spec) extends Marshal(spec) {
             case MOptional => throw new AssertionError("nested optional?")
             case m => f(arg, true)
           }
-        case e: MExtern => (if(needRef) e.java.boxed else e.java.typename) + (if(e.java.generic.get) args(tm) else "")
+        case e: MExtern => (if(needRef) e.java.boxed.get else e.java.typename.get) + (if(e.java.generic.get) args(tm) else "")
         case o =>
           val base = o match {
             case p: MPrimitive => if (needRef) p.jBoxed else p.jName

--- a/src/main/scala/djinni/Main.scala
+++ b/src/main/scala/djinni/Main.scala
@@ -34,7 +34,7 @@ object Main {
     var cppFileIdentStyle: IdentConverter = IdentStyle.underLower
     var cppOptionalTemplate: String = "std::optional"
     var cppOptionalHeader: String = "<optional>"
-    var cppEnumHashWorkaround : Boolean = true
+    var cppEnumHashWorkaround: Boolean = true
     var cppNnHeader: Option[String] = None
     var cppNnType: Option[String] = None
     var cppNnCheckExpression: Option[String] = None
@@ -47,7 +47,7 @@ object Main {
     var javaGenerateInterfaces: Boolean = false
     var javaNullableAnnotation: Option[String] = None
     var javaNonnullAnnotation: Option[String] = None
-    var javaImplementAndroidOsParcelable : Boolean = false
+    var javaImplementAndroidOsParcelable: Boolean = false
     var javaUseFinalForRecord: Boolean = true
     var jniOutFolder: Option[File] = None
     var jniHeaderOutFolderOptional: Option[File] = None
@@ -358,7 +358,25 @@ object Main {
       }
     }
 
+    // Resolve names in IDL file, check types.
     System.out.println("Resolving...")
+    resolver.resolve(
+      meta.defaults,
+      idl,
+      cppOutRequired = cppOutFolder.isDefined,
+      objcOutRequired = objcOutFolder.isDefined,
+      objcppOutRequired = objcppOutFolder.isDefined,
+      javaOutRequired = javaOutFolder.isDefined,
+      jniOutRequired = jniOutFolder.isDefined,
+      cppCliOutRequired = cppCliOutFolder.isDefined
+    ) match {
+      case Some(err) =>
+        System.err.println(err)
+        System.exit(1); return
+      case _ =>
+    }
+
+    System.out.println("Generating...")
     val outFileListWriter = if (outFileListPath.isDefined) {
       if (outFileListPath.get.getParentFile != null)
         createFolder("output file list", outFileListPath.get.getParentFile)
@@ -451,20 +469,10 @@ object Main {
       cWrapperBaseLibIncludePrefix,
       pyImportPrefix)
 
-    // Resolve names in IDL file, check types.
     try {
-      resolver.resolve(meta.defaults, idl, outSpec) match {
-        case Some(err) =>
-          System.err.println(err)
-          System.exit(1); return
-        case _ =>
-      }
-
-      System.out.println("Generating...")
       val r = generate(idl, outSpec)
       r.foreach(e => System.err.println("Error generating output: " + e))
-    }
-    finally {
+    } finally {
       if (outFileListWriter.isDefined) {
         outFileListWriter.get.close()
       }

--- a/src/main/scala/djinni/Main.scala
+++ b/src/main/scala/djinni/Main.scala
@@ -358,16 +358,7 @@ object Main {
       }
     }
 
-    // Resolve names in IDL file, check types.
     System.out.println("Resolving...")
-    resolver.resolve(meta.defaults, idl) match {
-      case Some(err) =>
-        System.err.println(err)
-        System.exit(1); return
-      case _ =>
-    }
-
-    System.out.println("Generating...")
     val outFileListWriter = if (outFileListPath.isDefined) {
       if (outFileListPath.get.getParentFile != null)
         createFolder("output file list", outFileListPath.get.getParentFile)
@@ -460,8 +451,16 @@ object Main {
       cWrapperBaseLibIncludePrefix,
       pyImportPrefix)
 
-
+    // Resolve names in IDL file, check types.
     try {
+      resolver.resolve(meta.defaults, idl, outSpec) match {
+        case Some(err) =>
+          System.err.println(err)
+          System.exit(1); return
+        case _ =>
+      }
+
+      System.out.println("Generating...")
       val r = generate(idl, outSpec)
       r.foreach(e => System.err.println("Error generating output: " + e))
     }

--- a/src/main/scala/djinni/ObjcGenerator.scala
+++ b/src/main/scala/djinni/ObjcGenerator.scala
@@ -283,7 +283,7 @@ class ObjcGenerator(spec: Spec) extends BaseObjcGenerator(spec) {
                   case _ => throw new AssertionError("Unreachable")
                 }
                 case e: MExtern => e.defType match {
-                  case DRecord => if(e.objc.pointer) {
+                  case DRecord => if(e.objc.pointer.get) {
                       w.w(s"[self.${idObjc.field(f.ident)} isEqual:typedOther.${idObjc.field(f.ident)}]")
                     } else {
                       w.w(s"self.${idObjc.field(f.ident)} == typedOther.${idObjc.field(f.ident)}")
@@ -319,7 +319,7 @@ class ObjcGenerator(spec: Spec) extends BaseObjcGenerator(spec) {
                 }
                 case e: MExtern => e.defType match {
                   case DEnum => w.w(s"(NSUInteger)self.${idObjc.field(f.ident)}")
-                  case DRecord => w.w("(" + e.objc.hash.format("self." + idObjc.field(f.ident)) + ")")
+                  case DRecord => w.w("(" + e.objc.hash.get.format("self." + idObjc.field(f.ident)) + ")")
                   case _ => throw new AssertionError("Unreachable")
                 }
                 case _ => w.w(s"self.${idObjc.field(f.ident)}.hash")
@@ -357,7 +357,7 @@ class ObjcGenerator(spec: Spec) extends BaseObjcGenerator(spec) {
                 case _ => throw new AssertionError("Unreachable")
               }
               case e: MExtern => e.defType match {
-                case DRecord => if(e.objc.pointer) w.wl(s"tempResult = [self.${idObjc.field(f.ident)} compare:other.${idObjc.field(f.ident)}];") else generatePrimitiveOrder(f.ident, w)
+                case DRecord => if(e.objc.pointer.get) w.wl(s"tempResult = [self.${idObjc.field(f.ident)} compare:other.${idObjc.field(f.ident)}];") else generatePrimitiveOrder(f.ident, w)
                 case DEnum => generatePrimitiveOrder(f.ident, w)
                 case _ => throw new AssertionError("Unreachable")
               }
@@ -390,7 +390,7 @@ class ObjcGenerator(spec: Spec) extends BaseObjcGenerator(spec) {
                 case _ => w.w(s"self.${idObjc.field(f.ident)}")
               }
               case e: MExtern =>
-                if (e.objc.pointer) {
+                if (e.objc.pointer.get) {
                   w.w(s"self.${idObjc.field(f.ident)}")
                 } else {
                   w.w(s"@(self.${idObjc.field(f.ident)})")

--- a/src/main/scala/djinni/ObjcMarshal.scala
+++ b/src/main/scala/djinni/ObjcMarshal.scala
@@ -30,7 +30,7 @@ class ObjcMarshal(spec: Spec) extends Marshal(spec) {
       case e: MExtern => e.defType match {
         case DEnum => None
         case DInterface => interfaceNullity
-        case DRecord => if(e.objc.pointer) nonnull else None
+        case DRecord => if(e.objc.pointer.get) nonnull else None
       }
       case _ => nonnull
     }
@@ -69,7 +69,7 @@ class ObjcMarshal(spec: Spec) extends Marshal(spec) {
         val prefix = if (r.ext.objc) spec.objcExtendedRecordIncludePrefix else spec.objcIncludePrefix
         List(ImportRef(q(prefix + headerName(d.name))))
     }
-    case e: MExtern => List(ImportRef(e.objc.header))
+    case e: MExtern => List(ImportRef(e.objc.header.get))
     case p: MParam => List()
   }
 
@@ -125,8 +125,8 @@ class ObjcMarshal(spec: Spec) extends Marshal(spec) {
                   (s"id<${idObjc.ty(d.name)}>", false)
             }
             case e: MExtern => e.body match {
-              case i: Interface => if(i.ext.objc) (s"id<${e.objc.typename}>", false) else (e.objc.typename, true)
-              case _ => if(needRef) (e.objc.boxed, true) else (e.objc.typename, e.objc.pointer)
+              case i: Interface => if(i.ext.objc) (s"id<${e.objc.typename.get}>", false) else (e.objc.typename.get, true)
+              case _ => if(needRef) (e.objc.boxed.get, true) else (e.objc.typename.get, e.objc.pointer.get)
             }
             case p: MParam => throw new AssertionError("Parameter should not happen at Obj-C top level")
           }

--- a/src/main/scala/djinni/ObjcppMarshal.scala
+++ b/src/main/scala/djinni/ObjcppMarshal.scala
@@ -41,7 +41,7 @@ class ObjcppMarshal(spec: Spec) extends Marshal(spec) {
         val objcName = d.name + (if (r.ext.objc) "_base" else "")
         List(ImportRef(q(spec.objcppIncludePrefix + privateHeaderName(objcName))))
     }
-    case e: MExtern => List(ImportRef(e.objcpp.header))
+    case e: MExtern => List(ImportRef(e.objcpp.header.get))
     case p: MParam => List()
   }
 
@@ -62,7 +62,7 @@ class ObjcppMarshal(spec: Spec) extends Marshal(spec) {
       case DEnum => withNs(Some("djinni"), s"Enum<${cppMarshal.fqTypename(tm)}, ${objcMarshal.fqTypename(tm)}>")
       case _ => withNs(Some(spec.objcppNamespace), helperClass(d.name))
     }
-    case e: MExtern => e.objcpp.translator
+    case e: MExtern => e.objcpp.translator.get
     case o => withNs(Some("djinni"), o match {
       case p: MPrimitive => p.idlName match {
         case "i8" => "I8"

--- a/src/main/scala/djinni/YamlGenerator.scala
+++ b/src/main/scala/djinni/YamlGenerator.scala
@@ -193,42 +193,50 @@ class YamlGenerator(spec: Spec) extends Generator(spec) {
 }
 
 object YamlGenerator {
-  def metaFromYaml(td: ExternTypeDecl, spec: Spec) = MExtern(
+  def metaFromYaml(
+      td: ExternTypeDecl,
+      cppOutRequired: Boolean,
+      objcOutRequired: Boolean,
+      objcppOutRequired: Boolean,
+      javaOutRequired: Boolean,
+      jniOutRequired: Boolean,
+      cppCliOutRequired: Boolean
+  ) = MExtern(
     td.ident.name.stripPrefix(td.properties("prefix").toString), // Make sure the generator uses this type with its original name for all intents and purposes
     td.params.size,
     defType(td),
     td.body,
     MExtern.Cpp(
-      nested(td, spec.cppOutFolder.isDefined, "cpp", "typename", _.toString),
-      nested(td, spec.cppOutFolder.isDefined, "cpp", "header", _.toString),
-      nested(td, spec.cppOutFolder.isDefined, "cpp", "byValue", _.asInstanceOf[Boolean])),
+      nested(td, isRequired = cppOutRequired, "cpp", "typename", _.toString),
+      nested(td, isRequired = cppOutRequired, "cpp", "header", _.toString),
+      nested(td, isRequired = cppOutRequired, "cpp", "byValue", _.asInstanceOf[Boolean])),
     MExtern.Objc(
-      nested(td, spec.objcOutFolder.isDefined, "objc", "typename", _.toString),
-      nested(td, spec.objcOutFolder.isDefined, "objc", "header", _.toString),
-      nested(td, spec.objcOutFolder.isDefined, "objc", "boxed", _.toString),
-      nested(td, spec.objcOutFolder.isDefined, "objc", "pointer", _.asInstanceOf[Boolean]),
-      nested(td, spec.objcOutFolder.isDefined, "objc", "hash", _.toString)),
+      nested(td, isRequired = objcOutRequired, "objc", "typename", _.toString),
+      nested(td, isRequired = objcOutRequired, "objc", "header", _.toString),
+      nested(td, isRequired = objcOutRequired, "objc", "boxed", _.toString),
+      nested(td, isRequired = objcOutRequired, "objc", "pointer", _.asInstanceOf[Boolean]),
+      nested(td, isRequired = objcOutRequired, "objc", "hash", _.toString)),
     MExtern.Objcpp(
-      nested(td, spec.objcppOutFolder.isDefined, "objcpp", "translator", _.toString),
-      nested(td, spec.objcppOutFolder.isDefined, "objcpp", "header", _.toString)),
+      nested(td, isRequired = objcppOutRequired, "objcpp", "translator", _.toString),
+      nested(td, isRequired = objcppOutRequired, "objcpp", "header", _.toString)),
     MExtern.Java(
-      nested(td, spec.javaOutFolder.isDefined, "java", "typename", _.toString),
-      nested(td, spec.javaOutFolder.isDefined, "java", "boxed", _.toString),
-      nested(td, spec.javaOutFolder.isDefined, "java", "reference", _.asInstanceOf[Boolean]),
-      nested(td, spec.javaOutFolder.isDefined, "java", "generic", _.asInstanceOf[Boolean]),
-      nested(td, spec.javaOutFolder.isDefined, "java", "hash", _.toString),
+      nested(td, isRequired = javaOutRequired, "java", "typename", _.toString),
+      nested(td, isRequired = javaOutRequired, "java", "boxed", _.toString),
+      nested(td, isRequired = javaOutRequired, "java", "reference", _.asInstanceOf[Boolean]),
+      nested(td, isRequired = javaOutRequired, "java", "generic", _.asInstanceOf[Boolean]),
+      nested(td, isRequired = javaOutRequired, "java", "hash", _.toString),
       nested(td, false, "java", "writeToParcel", _.toString) getOrElse "%s.writeToParcel(out, flags)",
       nested(td, false, "java", "readFromParcel", _.toString) getOrElse "new %s(in)"),
     MExtern.Jni(
-      nested(td, spec.jniOutFolder.isDefined, "jni", "translator", _.toString),
-      nested(td, spec.jniOutFolder.isDefined, "jni", "header", _.toString),
-      nested(td, spec.jniOutFolder.isDefined, "jni", "typename", _.toString),
-      nested(td, spec.jniOutFolder.isDefined, "jni", "typeSignature", _.toString)),
+      nested(td, isRequired = jniOutRequired, "jni", "translator", _.toString),
+      nested(td, isRequired = jniOutRequired, "jni", "header", _.toString),
+      nested(td, isRequired = jniOutRequired, "jni", "typename", _.toString),
+      nested(td, isRequired = jniOutRequired, "jni", "typeSignature", _.toString)),
     MExtern.Cs(
-      nested(td, spec.cppCliOutFolder.isDefined, "cs", "translator", _.toString),
-      nested(td, spec.cppCliOutFolder.isDefined, "cs", "header", _.toString),
-      nested(td, spec.cppCliOutFolder.isDefined, "cs", "typename", _.toString),
-      nested(td, spec.cppCliOutFolder.isDefined, "cs", "reference", _.asInstanceOf[Boolean]))
+      nested(td, isRequired = cppCliOutRequired, "cs", "translator", _.toString),
+      nested(td, isRequired = cppCliOutRequired, "cs", "header", _.toString),
+      nested(td, isRequired = cppCliOutRequired, "cs", "typename", _.toString),
+      nested(td, isRequired = cppCliOutRequired, "cs", "reference", _.asInstanceOf[Boolean]))
   )
 
   private def nested(td: ExternTypeDecl, key: String) = {

--- a/src/main/scala/djinni/YamlGenerator.scala
+++ b/src/main/scala/djinni/YamlGenerator.scala
@@ -235,10 +235,12 @@ object YamlGenerator {
     td.properties.get(key).collect { case m: JMap[_, _] => m.collect { case (k: String, v: Any) => (k, v) } }
   }
   private def nested[T](td: ExternTypeDecl, isRequired: Boolean, lang: String, key: String, convert: Any => T): Option[T] = {
-    nested(td, lang).map(m => m(key)).map(v => convert(v)) match {
-      case Some(v) => Some(v)
-      case None => if (isRequired) throw Error(td.ident.loc, s"missing '$lang' definitions").toException else None
-    }
+    nested(td, lang)
+      .map(m => m.get(key)).flatten
+      .map(v => convert(v)) match {
+        case None if isRequired => throw Error(td.ident.loc, s"missing '$lang' definitions").toException
+        case other => other
+      }
   }
 
   private def defType(td: ExternTypeDecl) = td.body match {

--- a/src/main/scala/djinni/YamlGenerator.scala
+++ b/src/main/scala/djinni/YamlGenerator.scala
@@ -198,40 +198,43 @@ object YamlGenerator {
     defType(td),
     td.body,
     MExtern.Cpp(
-      nested(td, "cpp")("typename").toString,
-      nested(td, "cpp")("header").toString,
-      nested(td, "cpp")("byValue").asInstanceOf[Boolean]),
+      nested(td, "cpp", "typename", _.toString),
+      nested(td, "cpp", "header", _.toString),
+      nested(td, "cpp", "byValue", _.asInstanceOf[Boolean])),
     MExtern.Objc(
-      nested(td, "objc")("typename").toString,
-      nested(td, "objc")("header").toString,
-      nested(td, "objc")("boxed").toString,
-      nested(td, "objc")("pointer").asInstanceOf[Boolean],
-      nested(td, "objc")("hash").toString),
+      nested(td, "objc", "typename", _.toString),
+      nested(td, "objc", "header", _.toString),
+      nested(td, "objc", "boxed", _.toString),
+      nested(td, "objc", "pointer", _.asInstanceOf[Boolean]),
+      nested(td, "objc", "hash", _.toString)),
     MExtern.Objcpp(
-      nested(td, "objcpp")("translator").toString,
-      nested(td, "objcpp")("header").toString),
+      nested(td, "objcpp", "translator", _.toString),
+      nested(td, "objcpp", "header", _.toString)),
     MExtern.Java(
-      nested(td, "java")("typename").toString,
-      nested(td, "java")("boxed").toString,
-      nested(td, "java")("reference").asInstanceOf[Boolean],
-      nested(td, "java")("generic").asInstanceOf[Boolean],
-      nested(td, "java")("hash").toString,
-      if (nested(td, "java") contains "writeToParcel") nested(td, "java")("writeToParcel").toString else "%s.writeToParcel(out, flags)",
-      if (nested(td, "java") contains "readFromParcel") nested(td, "java")("readFromParcel").toString else "new %s(in)"),
+      nested(td, "java", "typename", _.toString),
+      nested(td, "java", "boxed", _.toString),
+      nested(td, "java", "reference", _.asInstanceOf[Boolean]),
+      nested(td, "java", "generic", _.asInstanceOf[Boolean]),
+      nested(td, "java", "hash", _.toString),
+      nested(td, "java", "writeToParcel", _.toString) getOrElse "%s.writeToParcel(out, flags)",
+      nested(td, "java", "readFromParcel", _.toString) getOrElse "new %s(in)"),
     MExtern.Jni(
-      nested(td, "jni")("translator").toString,
-      nested(td, "jni")("header").toString,
-      nested(td, "jni")("typename").toString,
-      nested(td, "jni")("typeSignature").toString),
+      nested(td, "jni", "translator", _.toString),
+      nested(td, "jni", "header", _.toString),
+      nested(td, "jni", "typename", _.toString),
+      nested(td, "jni", "typeSignature", _.toString)),
     MExtern.Cs(
-      nested(td, "cs")("translator").toString,
-      nested(td, "cs")("header").toString,
-      nested(td, "cs")("typename").toString,
-      nested(td, "cs")("reference").asInstanceOf[Boolean])
+      nested(td, "cs", "translator", _.toString),
+      nested(td, "cs", "header", _.toString),
+      nested(td, "cs", "typename", _.toString),
+      nested(td, "cs", "reference", _.asInstanceOf[Boolean]))
   )
 
   private def nested(td: ExternTypeDecl, key: String) = {
-    td.properties.get(key).collect { case m: JMap[_, _] => m.collect { case (k: String, v: Any) => (k, v) } } getOrElse(Map[String, Any]())
+    td.properties.get(key).collect { case m: JMap[_, _] => m.collect { case (k: String, v: Any) => (k, v) } }
+  }
+  private def nested[T](td: ExternTypeDecl, lang: String, key: String, convert: Any => T): Option[T] = {
+    nested(td, lang).map(m => m(key)).map(v => convert(v))
   }
 
   private def defType(td: ExternTypeDecl) = td.body match {

--- a/src/main/scala/djinni/meta.scala
+++ b/src/main/scala/djinni/meta.scala
@@ -37,41 +37,41 @@ object MExtern {
   // All typenames are fully qualified in their respective language.
   // TODO: names of enum values and record fields as written in code for use in constants (do not use IdentStyle)
   case class Cpp(
-    typename: String,
-    header: String,
-    byValue: Boolean // Whether to pass struct by value in C++ (e.g. std::chrono::duration). Only used for "record" types.
+    typename: Option[String],
+    header: Option[String],
+    byValue: Option[Boolean] // Whether to pass struct by value in C++ (e.g. std::chrono::duration). Only used for "record" types.
   )
   case class Objc(
-    typename: String,
-    header: String,
-    boxed: String, // Fully qualified Objective-C typename, must be an object. Only used for "record" types.
-    pointer: Boolean, // True to construct pointer types and make it eligible for "nonnull" qualifier. Only used for "record" types.
-    hash: String // A well-formed expression to get the hash value. Must be a format string with a single "%s" placeholder. Only used for "record" types with "eq" deriving when needed.
+    typename: Option[String],
+    header: Option[String],
+    boxed: Option[String], // Fully qualified Objective-C typename, must be an object. Only used for "record" types.
+    pointer: Option[Boolean], // True to construct pointer types and make it eligible for "nonnull" qualifier. Only used for "record" types.
+    hash: Option[String] // A well-formed expression to get the hash value. Must be a format string with a single "%s" placeholder. Only used for "record" types with "eq" deriving when needed.
   )
   case class Objcpp(
-    translator: String, // C++ typename containing toCpp/fromCpp methods
-    header: String // Where to find the translator class
+    translator: Option[String], // C++ typename containing toCpp/fromCpp methods
+    header: Option[String] // Where to find the translator class
   )
   case class Java(
-    typename: String,
-    boxed: String, // Java typename used if boxing is required, must be an object.
-    reference: Boolean, // True if the unboxed type is an object reference and qualifies for any kind of "nonnull" annotation in Java. Only used for "record" types.
-    generic: Boolean, // Set to false to exclude type arguments from the Java class. This is should be true by default. Useful if template arguments are only used in C++.
-    hash: String, // A well-formed expression to get the hash value. Must be a format string with a single "%s" placeholder. Only used for "record" types types with "eq" deriving when needed.
+    typename: Option[String],
+    boxed: Option[String], // Java typename used if boxing is required, must be an object.
+    reference: Option[Boolean], // True if the unboxed type is an object reference and qualifies for any kind of "nonnull" annotation in Java. Only used for "record" types.
+    generic: Option[Boolean], // Set to false to exclude type arguments from the Java class. This is should be true by default. Useful if template arguments are only used in C++.
+    hash: Option[String], // A well-formed expression to get the hash value. Must be a format string with a single "%s" placeholder. Only used for "record" types types with "eq" deriving when needed.
     writeToParcel: String, // A well-formed expression to write value into android.os.Parcel. Must be a format string with a single "%s" placeholder. Only used for "record" types types
     readFromParcel: String // A well-formed expression to read value from android.os.Parcel. Must be a format string with a single "%s" placeholder. Only used for "record" types types
   )
   case class Jni(
-    translator: String, // C++ typename containing toCpp/fromCpp methods
-    header: String, // Where to find the translator class
-    typename: String, // The JNI type to use (e.g. jobject, jstring)
-    typeSignature: String // The mangled Java type signature (e.g. "Ljava/lang/String;")
+    translator: Option[String], // C++ typename containing toCpp/fromCpp methods
+    header: Option[String], // Where to find the translator class
+    typename: Option[String], // The JNI type to use (e.g. jobject, jstring)
+    typeSignature: Option[String] // The mangled Java type signature (e.g. "Ljava/lang/String;")
   )
   case class Cs(
-    translator: String, // C++ typename containing ToCpp/FromCpp methods
-    header: String, // Where to find the translator class
-    typename: String,
-    reference: Boolean
+    translator: Option[String], // C++ typename containing ToCpp/FromCpp methods
+    header: Option[String], // Where to find the translator class
+    typename: Option[String],
+    reference: Option[Boolean]
   )
 }
 

--- a/src/main/scala/djinni/resolver.scala
+++ b/src/main/scala/djinni/resolver.scala
@@ -17,9 +17,10 @@
 package djinni
 
 import djinni.ast.Record.DerivingType
-import djinni.syntax._
 import djinni.ast._
+import djinni.generatorTools._
 import djinni.meta._
+import djinni.syntax._
 import scala.collection.immutable
 import scala.collection.mutable
 import scala.collection.mutable.ArrayBuffer
@@ -28,7 +29,7 @@ package object resolver {
 
 type Scope = immutable.Map[String,Meta]
 
-def resolve(metas: Scope, idl: Seq[TypeDecl]): Option[Error] = {
+def resolve(metas: Scope, idl: Seq[TypeDecl], spec: Spec): Option[Error] = {
 
   try {
     var topScope = metas
@@ -49,7 +50,7 @@ def resolve(metas: Scope, idl: Seq[TypeDecl]): Option[Error] = {
       }
       topScope = topScope.updated(typeDecl.ident.name, typeDecl match {
         case td: InternTypeDecl => MDef(typeDecl.ident.name, typeDecl.params.length, defType, typeDecl.body)
-        case td: ExternTypeDecl => YamlGenerator.metaFromYaml(td)
+        case td: ExternTypeDecl => YamlGenerator.metaFromYaml(td, spec)
       })
     }
 

--- a/src/main/scala/djinni/resolver.scala
+++ b/src/main/scala/djinni/resolver.scala
@@ -29,7 +29,16 @@ package object resolver {
 
 type Scope = immutable.Map[String,Meta]
 
-def resolve(metas: Scope, idl: Seq[TypeDecl], spec: Spec): Option[Error] = {
+def resolve(
+    metas: Scope,
+    idl: Seq[TypeDecl],
+    cppOutRequired: Boolean,
+    objcOutRequired: Boolean,
+    objcppOutRequired: Boolean,
+    javaOutRequired: Boolean,
+    jniOutRequired: Boolean,
+    cppCliOutRequired: Boolean
+): Option[Error] = {
 
   try {
     var topScope = metas
@@ -50,7 +59,15 @@ def resolve(metas: Scope, idl: Seq[TypeDecl], spec: Spec): Option[Error] = {
       }
       topScope = topScope.updated(typeDecl.ident.name, typeDecl match {
         case td: InternTypeDecl => MDef(typeDecl.ident.name, typeDecl.params.length, defType, typeDecl.body)
-        case td: ExternTypeDecl => YamlGenerator.metaFromYaml(td, spec)
+        case td: ExternTypeDecl => YamlGenerator.metaFromYaml(
+          td,
+          cppOutRequired = cppOutRequired,
+          objcOutRequired = objcOutRequired,
+          objcppOutRequired = objcppOutRequired,
+          javaOutRequired = javaOutRequired,
+          jniOutRequired = jniOutRequired,
+          cppCliOutRequired = cppCliOutRequired
+        )
       })
     }
 


### PR DESCRIPTION
When resolving YAML, if missing the definitions for one of the languages that are being generated a descriptive error message will be printed. For instance, when running djinni with `--cppcli-out`, if any of the keys for `cs` are missing the generation will fail with the following error:

```
/path/to/file.yaml (1.1): missing 'cs' definitions
```

That was achieved by making most fields of `MExtern` optional, requiring a call to `get` to be able to access their values; the check that generates the error message above ensures that any `Option[...]` field will have `Some(value)` (i.e. not `None`) by the time we call `get` on it.

In order to have the command line parameters available when resolving the YAML definitions I had to shuffle some code in `Main.scala`, causing a few lines that were originally in the "generation" phase to be executed during the "resolving" phase.

Fixes https://github.com/cross-language-cpp/djinni-generator/issues/48.