### PR TITLE
Suppress depreciation warning for Java finalze call

### DIFF
--- a/src/it/resources/expected/my_cpp_interface/java/MyCppInterface.java
+++ b/src/it/resources/expected/my_cpp_interface/java/MyCppInterface.java
@@ -37,6 +37,7 @@ public abstract class MyCppInterface {
             boolean destroyed = this.destroyed.getAndSet(true);
             if (!destroyed) nativeDestroy(this.nativeRef);
         }
+        @SuppressWarnings("deprecation")
         protected void finalize() throws java.lang.Throwable
         {
             _djinni_private_destroy();

--- a/src/main/scala/djinni/JavaGenerator.scala
+++ b/src/main/scala/djinni/JavaGenerator.scala
@@ -186,7 +186,7 @@ class JavaGenerator(spec: Spec) extends Generator(spec) {
             w.wl
           }
         }
-        
+
         if (i.ext.cpp) {
           w.wl
           javaAnnotationHeader.foreach(w.wl)
@@ -204,6 +204,7 @@ class JavaGenerator(spec: Spec) extends Generator(spec) {
               w.wl("boolean destroyed = this.destroyed.getAndSet(true);")
               w.wl("if (!destroyed) nativeDestroy(this.nativeRef);")
             }
+            w.wl("@SuppressWarnings(\"deprecation\")")
             w.wl("protected void finalize() throws java.lang.Throwable").braced {
               w.wl("_djinni_private_destroy();")
               w.wl("super.finalize();")


### PR DESCRIPTION
Fixes #16

Adds a @SuppressWarnings("deprecation") to the generated finalize call.

Since there seem not to be a way to live without the finalize methode,
we should not inject warnings into use code for that.