### PR TITLE
clean test output dir at the begin of test run

### DIFF
--- a/src/it/resources/.gitignore
+++ b/src/it/resources/.gitignore
@@ -1,0 +1,2 @@
+# Everything generated from tests
+result/*

--- a/src/it/resources/result/.gitignore
+++ b/src/it/resources/result/.gitignore
@@ -1,4 +1,0 @@
-# Ignore everything in this directory
-*
-# Except this file
-!.gitignore

--- a/src/it/scala/djinni/GeneratorIntegrationTest.scala
+++ b/src/it/scala/djinni/GeneratorIntegrationTest.scala
@@ -7,6 +7,9 @@ import org.scalatest.prop.TableDrivenPropertyChecks._
 class GeneratorIntegrationTest extends IntegrationTest with GivenWhenThen {
 
   describe("djinni file generation") {
+
+    removeTestOutputDirectory()
+
     val djinniTypes = Table(
       ("idlFile",
         "cppFilenames",

--- a/src/it/scala/djinni/IntegrationTest.scala
+++ b/src/it/scala/djinni/IntegrationTest.scala
@@ -6,6 +6,10 @@ import org.scalatest.Matchers.{be, convertToAnyShouldWrapper, equal, noException
 import scala.io.Source
 import scala.sys.process._
 
+import scala.reflect.io.Directory
+import java.io.File
+
+
 /**
   * Base class for integration tests, providing a few handy helper functions
   */
@@ -79,7 +83,7 @@ class IntegrationTest extends FunSpec {
     *
     * @return command line params to pass to the djinni generator.
     */
-  def djinniParams(idl: String, baseOutputPath: String = "src/it/resources/result",
+  def djinniParams(idl: String, baseOutputPath: String = "src/it/resources/result", // this should never change, see removeTestOutputDirectory, and it is also used on other locations
                    cpp: Boolean = true, java: Boolean = true, objc: Boolean = true,
                    python: Boolean = true, cWrapper: Boolean = true, cppCLI: Boolean = true,
                    useNNHeader: Boolean = false): String = {
@@ -150,6 +154,13 @@ class IntegrationTest extends FunSpec {
       resultFile.mkString should equal (expectationFile.mkString)
       resultFile.close()
       expectationFile.close()
+    }
+  }
+
+  def removeTestOutputDirectory(baseOutputPath: String = "src/it/resources/result") {
+    val directory = new Directory(new File(baseOutputPath))
+    if (directory.deleteRecursively()) {
+      System.console.printf("[info] Clean up old generated test output/files.\n")
     }
   }
 


### PR DESCRIPTION
Adds functionality to clean a directory with generated files, and does so at the begin of a test run.

This should fix #57 , 
It might be that there is still a dependency between tests
and a test might generated files a following tests checks,
but until we detect such a case, this should be 'good enough'