### PR TITLE
Add bridging header to generated files list

### DIFF
--- a/src/it/resources/expected/all_datatypes/generated-files.txt
+++ b/src/it/resources/expected/all_datatypes/generated-files.txt
@@ -7,6 +7,7 @@ src/it/resources/result/all_datatypes/objc-headers/ITAllDatatypes.h
 src/it/resources/result/all_datatypes/objc/ITAllDatatypes.mm
 src/it/resources/result/all_datatypes/objcpp-headers/ITAllDatatypes+Private.h
 src/it/resources/result/all_datatypes/objcpp/ITAllDatatypes+Private.mm
+src/it/resources/result/all_datatypes/objc-headers/bridging-header.h
 src/it/resources/result/all_datatypes/cppcli/AllDatatypes.hpp
 src/it/resources/result/all_datatypes/cppcli/AllDatatypes.cpp
 src/it/resources/result/all_datatypes/python/dh__list_bool.py

--- a/src/it/resources/expected/my_client_interface/generated-files.txt
+++ b/src/it/resources/expected/my_client_interface/generated-files.txt
@@ -6,6 +6,7 @@ src/it/resources/result/my_client_interface/jni/my_client_interface.cpp
 src/it/resources/result/my_client_interface/objc-headers/ITMyClientInterface.h
 src/it/resources/result/my_client_interface/objcpp-headers/ITMyClientInterface+Private.h
 src/it/resources/result/my_client_interface/objcpp/ITMyClientInterface+Private.mm
+src/it/resources/result/my_client_interface/objc-headers/bridging-header.h
 src/it/resources/result/my_client_interface/cppcli/MyClientInterface.hpp
 src/it/resources/result/my_client_interface/cppcli/MyClientInterface.cpp
 src/it/resources/result/my_client_interface/python/my_client_interface.py

--- a/src/it/resources/expected/my_cpp_interface/generated-files.txt
+++ b/src/it/resources/expected/my_cpp_interface/generated-files.txt
@@ -8,6 +8,7 @@ src/it/resources/result/my_cpp_interface/objc-headers/ITMyCppInterface.h
 src/it/resources/result/my_cpp_interface/objc/ITMyCppInterface.mm
 src/it/resources/result/my_cpp_interface/objcpp-headers/ITMyCppInterface+Private.h
 src/it/resources/result/my_cpp_interface/objcpp/ITMyCppInterface+Private.mm
+src/it/resources/result/my_cpp_interface/objc-headers/bridging-header.h
 src/it/resources/result/my_cpp_interface/cppcli/MyCppInterface.hpp
 src/it/resources/result/my_cpp_interface/cppcli/MyCppInterface.cpp
 src/it/resources/result/my_cpp_interface/python/my_cpp_interface.py

--- a/src/it/resources/expected/my_enum/generated-files.txt
+++ b/src/it/resources/expected/my_enum/generated-files.txt
@@ -4,6 +4,7 @@ src/it/resources/result/my_enum/jni/djinni_jni_main.cpp
 src/it/resources/result/my_enum/jni-headers/my_enum.hpp
 src/it/resources/result/my_enum/objc-headers/ITMyEnum.h
 src/it/resources/result/my_enum/objcpp-headers/ITMyEnum+Private.h
+src/it/resources/result/my_enum/objc-headers/bridging-header.h
 src/it/resources/result/my_enum/cppcli/MyEnum.hpp
 src/it/resources/result/my_enum/cppcli/MyEnum.cpp
 src/it/resources/result/my_enum/python/my_enum.py

--- a/src/it/resources/expected/my_flags/generated-files.txt
+++ b/src/it/resources/expected/my_flags/generated-files.txt
@@ -4,6 +4,7 @@ src/it/resources/result/my_flags/jni/djinni_jni_main.cpp
 src/it/resources/result/my_flags/jni-headers/my_flags.hpp
 src/it/resources/result/my_flags/objc-headers/ITMyFlags.h
 src/it/resources/result/my_flags/objcpp-headers/ITMyFlags+Private.h
+src/it/resources/result/my_flags/objc-headers/bridging-header.h
 src/it/resources/result/my_flags/cppcli/MyFlags.hpp
 src/it/resources/result/my_flags/cppcli/MyFlags.cpp
 src/it/resources/result/my_flags/python/my_flags.py

--- a/src/it/resources/expected/my_record/generated-files.txt
+++ b/src/it/resources/expected/my_record/generated-files.txt
@@ -8,6 +8,7 @@ src/it/resources/result/my_record/objc-headers/ITMyRecord.h
 src/it/resources/result/my_record/objc/ITMyRecord.mm
 src/it/resources/result/my_record/objcpp-headers/ITMyRecord+Private.h
 src/it/resources/result/my_record/objcpp/ITMyRecord+Private.mm
+src/it/resources/result/my_record/objc-headers/bridging-header.h
 src/it/resources/result/my_record/cppcli/MyRecord.hpp
 src/it/resources/result/my_record/cppcli/MyRecord.cpp
 src/it/resources/result/my_record/python/dh__set_string.py

--- a/src/it/resources/expected/using_custom_datatypes/generated-files.txt
+++ b/src/it/resources/expected/using_custom_datatypes/generated-files.txt
@@ -15,6 +15,7 @@ src/it/resources/result/using_custom_datatypes/objcpp-headers/ITCustomDatatype+P
 src/it/resources/result/using_custom_datatypes/objcpp/ITCustomDatatype+Private.mm
 src/it/resources/result/using_custom_datatypes/objcpp-headers/ITOtherRecord+Private.h
 src/it/resources/result/using_custom_datatypes/objcpp/ITOtherRecord+Private.mm
+src/it/resources/result/using_custom_datatypes/objc-headers/bridging-header.h
 src/it/resources/result/using_custom_datatypes/cppcli/CustomDatatype.hpp
 src/it/resources/result/using_custom_datatypes/cppcli/CustomDatatype.cpp
 src/it/resources/result/using_custom_datatypes/cppcli/OtherRecord.hpp

--- a/src/main/scala/djinni/generator.scala
+++ b/src/main/scala/djinni/generator.scala
@@ -272,6 +272,9 @@ package object generatorTools {
           SwiftBridgingHeaderGenerator.writeAutogenerationWarning(spec.objcSwiftBridgingHeaderName.get, spec.objcSwiftBridgingHeaderWriter.get)
           SwiftBridgingHeaderGenerator.writeBridgingVars(spec.objcSwiftBridgingHeaderName.get, spec.objcSwiftBridgingHeaderWriter.get)
           new SwiftBridgingHeaderGenerator(spec).generate(idl)
+          if (spec.outFileListWriter.isDefined) {
+            spec.outFileListWriter.get.write(FilenameUtils.separatorsToUnix(new File(spec.objcHeaderOutFolder.get, spec.objcSwiftBridgingHeaderName.get + ".h").getPath) + "\n")
+          }
         }
       }
       if (spec.cppCliOutFolder.isDefined) {


### PR DESCRIPTION
Fixes #54

If the option `--list-out-files` is used, the generated bridging header
will be included (if one is generated)