### PR TITLE
Add docs for #26

### DIFF
--- a/docs/setup.md
+++ b/docs/setup.md
@@ -26,7 +26,7 @@ We have a brew tap!
 Add the tap:
 
 ```bash
-brew cross-language-cpp/brew https://github.com/cross-language-cpp/brew.git
+brew tap cross-language-cpp/brew https://github.com/cross-language-cpp/brew.git
 ```
 
 Install the djinni generator:

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -19,6 +19,22 @@ asdf plugin add djinni
 asdf install djinni latest
 ```
 
+#### MacOS homebrew
+
+We have a brew tap!
+
+Add the tap:
+
+```bash
+brew cross-language-cpp/brew https://github.com/cross-language-cpp/brew.git
+```
+
+Install the djinni generator:
+
+```bash
+brew install djinni
+```
+
 ### Windows
 
 [![GitHub release (latest by date)](https://img.shields.io/github/v/release/cross-language-cpp/djinni-generator?label=Download&logo=windows&style=for-the-badge)](https://github.com/cross-language-cpp/djinni-generator/releases/latest/download/djinni.bat)


### PR DESCRIPTION
#26 was closed by a new repo I created, but it should had been closed by that PR.
(Sorry for that surprise, I was not aware I can close issues via commit message cross repo wise) 

This is the doc for the addition, installing the generator via homebrew. Closes #26 

**Pls note**, this will add a stage to the release of a new generator version, we need to update the cask, 
(until we figure out how autoupdate works)
