### PR TITLE
Only initialize the objcSwiftBridgingHeaderWriter if generating files

### DIFF
--- a/src/it/scala/djinni/GeneratorIntegrationTest.scala
+++ b/src/it/scala/djinni/GeneratorIntegrationTest.scala
@@ -298,5 +298,27 @@ class GeneratorIntegrationTest extends IntegrationTest with GivenWhenThen {
       Then("the generation should fail gracefully if code for Objective-C is generated")
       a [RuntimeException] should be thrownBy djinni(s"--idl src/it/resources/date_no_cs.djinni --objc-out $outputPath")
     }
+    
+     it(s"skip-generate should not generate any files") {
+        var idlFile = "all_datatypes"
+        var outputPath = "src/it/resources/result/skip_generate"
+        Given(s"`$idlFile.djinni`")
+        When(s"passing skip-generation true")
+
+        djinni(djinniParams(idlFile, outputPath) + " --skip-generation true")
+
+        Then(s"`$outputPath` should have been created")
+        var dir = new java.io.File(outputPath, idlFile)
+        dir.exists should be (true)
+
+        Then(s"genreated-files.txt should have been generated")
+        val gen = new java.io.File(dir,"generated-files.txt")
+        gen.exists should be (true)
+
+        Then(s"only the generated-files.txt should be generated")
+        var files = dir.listFiles()
+        files should contain only ( gen )
+      }
+
   }
 }

--- a/src/main/scala/djinni/Main.scala
+++ b/src/main/scala/djinni/Main.scala
@@ -399,7 +399,7 @@ object Main {
     } else {
       None
     }
-    val objcSwiftBridgingHeaderWriter = if (objcSwiftBridgingHeaderName.isDefined && objcOutFolder.isDefined) {
+    val objcSwiftBridgingHeaderWriter = if (objcSwiftBridgingHeaderName.isDefined && objcOutFolder.isDefined && !skipGeneration) {
       val objcSwiftBridgingHeaderFile = new File(objcHeaderOutFolder.get.getPath, objcSwiftBridgingHeaderName.get + ".h")
       if (objcSwiftBridgingHeaderFile.getParentFile != null)
         createFolder("output file list", objcSwiftBridgingHeaderFile.getParentFile)

--- a/src/main/scala/djinni/generator.scala
+++ b/src/main/scala/djinni/generator.scala
@@ -267,14 +267,14 @@ package object generatorTools {
         }
         new ObjcppGenerator(spec).generate(idl)
       }
-      if (!spec.skipGeneration) {
+      if (spec.objcSwiftBridgingHeaderName.isDefined && spec.objcOutFolder.isDefined) {
+        if (spec.outFileListWriter.isDefined) {
+          spec.outFileListWriter.get.write(FilenameUtils.separatorsToUnix(new File(spec.objcHeaderOutFolder.get, spec.objcSwiftBridgingHeaderName.get + ".h").getPath) + "\n")
+        }
         if (spec.objcSwiftBridgingHeaderWriter.isDefined) {
           SwiftBridgingHeaderGenerator.writeAutogenerationWarning(spec.objcSwiftBridgingHeaderName.get, spec.objcSwiftBridgingHeaderWriter.get)
           SwiftBridgingHeaderGenerator.writeBridgingVars(spec.objcSwiftBridgingHeaderName.get, spec.objcSwiftBridgingHeaderWriter.get)
           new SwiftBridgingHeaderGenerator(spec).generate(idl)
-          if (spec.outFileListWriter.isDefined) {
-            spec.outFileListWriter.get.write(FilenameUtils.separatorsToUnix(new File(spec.objcHeaderOutFolder.get, spec.objcSwiftBridgingHeaderName.get + ".h").getPath) + "\n")
-          }
         }
       }
       if (spec.cppCliOutFolder.isDefined) {


### PR DESCRIPTION
The Swift bridging header would be created as a 0 byte file of —skip-generation true was passed.