### PR TITLE
add missing comments to generated output

### DIFF
--- a/src/it/resources/expected/my_cpp_interface/cpp-headers/my_cpp_interface.hpp
+++ b/src/it/resources/expected/my_cpp_interface/cpp-headers/my_cpp_interface.hpp
@@ -6,6 +6,7 @@
 #include <cstdint>
 #include <string>
 
+/** interface comment */
 class MyCppInterface {
 public:
     virtual ~MyCppInterface() {}
@@ -13,6 +14,7 @@ public:
     /** Interfaces can also have constants */
     static constexpr int32_t VERSION = 1;
 
+    /** method comment */
     virtual void method_returning_nothing(int32_t value) = 0;
 
     virtual int32_t method_returning_some_type(const std::string & key) = 0;

--- a/src/it/resources/expected/my_cpp_interface/cppcli/MyCppInterface.hpp
+++ b/src/it/resources/expected/my_cpp_interface/cppcli/MyCppInterface.hpp
@@ -6,8 +6,10 @@
 #include "../cpp-headers/my_cpp_interface.hpp"
 #include <memory>
 
+/** interface comment */
 public ref class MyCppInterface abstract {
 public:
+    /** method comment */
     virtual void MethodReturningNothing(int value) abstract;
 
     virtual int MethodReturningSomeType(System::String^ key) abstract;

--- a/src/it/resources/expected/my_cpp_interface/java/MyCppInterface.java
+++ b/src/it/resources/expected/my_cpp_interface/java/MyCppInterface.java
@@ -5,10 +5,12 @@ package djinni.it;
 
 import java.util.concurrent.atomic.AtomicBoolean;
 
+/** interface comment */
 public abstract class MyCppInterface {
     /** Interfaces can also have constants */
     public static final int VERSION = 1;
 
+    /** method comment */
     public abstract void methodReturningNothing(int value);
 
     public abstract int methodReturningSomeType(String key);

--- a/src/it/resources/expected/my_cpp_interface/objc-headers/ITMyCppInterface.h
+++ b/src/it/resources/expected/my_cpp_interface/objc-headers/ITMyCppInterface.h
@@ -6,8 +6,10 @@
 /** Interfaces can also have constants */
 extern int32_t const ITMyCppInterfaceVersion;
 
+/** interface comment */
 @interface ITMyCppInterface : NSObject
 
+/** method comment */
 - (void)methodReturningNothing:(int32_t)value;
 
 - (int32_t)methodReturningSomeType:(nonnull NSString *)key;

--- a/src/it/resources/expected/my_cpp_interface/python/my_cpp_interface.py
+++ b/src/it/resources/expected/my_cpp_interface/python/my_cpp_interface.py
@@ -13,6 +13,7 @@ from djinni import exception # this forces run of __init__.py which gives cpp op
 
 class MyCppInterface(with_metaclass(ABCMeta)):
     """
+     interface comment
     Constants
         VERSION: Interfaces can also have constants
     """
@@ -21,6 +22,7 @@ class MyCppInterface(with_metaclass(ABCMeta)):
 
     @abstractmethod
     def method_returning_nothing(self, value):
+        """ method comment """
         raise NotImplementedError
 
     @abstractmethod

--- a/src/it/resources/expected/my_enum/cpp-headers/my_enum.hpp
+++ b/src/it/resources/expected/my_enum/cpp-headers/my_enum.hpp
@@ -5,7 +5,9 @@
 
 #include <functional>
 
+/** enum comment */
 enum class MyEnum : int {
+    /** enum option comment */
     OPTION1,
     OPTION2,
     OPTION3,

--- a/src/it/resources/expected/my_enum/cppcli/MyEnum.hpp
+++ b/src/it/resources/expected/my_enum/cppcli/MyEnum.hpp
@@ -5,7 +5,9 @@
 
 #include "../cpp-headers/my_enum.hpp"
 
+/** enum comment */
 public enum class MyEnum {
+    /** enum option comment */
     Option1,
     Option2,
     Option3,

--- a/src/it/resources/expected/my_enum/java/MyEnum.java
+++ b/src/it/resources/expected/my_enum/java/MyEnum.java
@@ -3,7 +3,9 @@
 
 package djinni.it;
 
+/** enum comment */
 public enum MyEnum {
+    /** enum option comment */
     OPTION1,
     OPTION2,
     OPTION3,

--- a/src/it/resources/expected/my_enum/objc-headers/ITMyEnum.h
+++ b/src/it/resources/expected/my_enum/objc-headers/ITMyEnum.h
@@ -3,8 +3,10 @@
 
 #import <Foundation/Foundation.h>
 
+/** enum comment */
 typedef NS_ENUM(NSInteger, ITMyEnum)
 {
+    /** enum option comment */
     ITMyEnumOption1,
     ITMyEnumOption2,
     ITMyEnumOption3,

--- a/src/it/resources/expected/my_enum/python/my_enum.py
+++ b/src/it/resources/expected/my_enum/python/my_enum.py
@@ -9,6 +9,9 @@ from djinni import exception # this forces run of __init__.py which gives cpp op
 from enum import IntEnum
 
 class MyEnum(IntEnum):
+    """ enum comment """
+
+    """ enum option comment """
     Option1 = 0
     Option2 = 1
     Option3 = 2

--- a/src/it/resources/expected/my_flags/cpp-headers/my_flags.hpp
+++ b/src/it/resources/expected/my_flags/cpp-headers/my_flags.hpp
@@ -5,8 +5,10 @@
 
 #include <functional>
 
+/** flag comment */
 enum class MyFlags : unsigned {
     NO_FLAGS = 0,
+    /** flag option comment */
     FLAG1 = 1 << 0,
     FLAG2 = 1 << 1,
     FLAG3 = 1 << 2,

--- a/src/it/resources/expected/my_flags/cppcli/MyFlags.hpp
+++ b/src/it/resources/expected/my_flags/cppcli/MyFlags.hpp
@@ -5,9 +5,11 @@
 
 #include "../cpp-headers/my_flags.hpp"
 
+/** flag comment */
 [System::Flags]
 public enum class MyFlags {
     NoFlags = 0,
+    /** flag option comment */
     Flag1 = 1 << 0,
     Flag2 = 1 << 1,
     Flag3 = 1 << 2,

--- a/src/it/resources/expected/my_flags/java/MyFlags.java
+++ b/src/it/resources/expected/my_flags/java/MyFlags.java
@@ -3,7 +3,9 @@
 
 package djinni.it;
 
+/** flag comment */
 public enum MyFlags {
+    /** flag option comment */
     FLAG1,
     FLAG2,
     FLAG3,

--- a/src/it/resources/expected/my_flags/objc-headers/ITMyFlags.h
+++ b/src/it/resources/expected/my_flags/objc-headers/ITMyFlags.h
@@ -3,9 +3,11 @@
 
 #import <Foundation/Foundation.h>
 
+/** flag comment */
 typedef NS_OPTIONS(NSUInteger, ITMyFlags)
 {
     ITMyFlagsNoFlags = 0,
+    /** flag option comment */
     ITMyFlagsFlag1 = 1 << 0,
     ITMyFlagsFlag2 = 1 << 1,
     ITMyFlagsFlag3 = 1 << 2,

--- a/src/it/resources/expected/my_flags/python/my_flags.py
+++ b/src/it/resources/expected/my_flags/python/my_flags.py
@@ -9,7 +9,10 @@ from djinni import exception # this forces run of __init__.py which gives cpp op
 from enum import IntFlag
 
 class MyFlags(IntFlag):
+    """ flag comment """
+
     No_Flags = 0
+    """ flag option comment """
     Flag1 = 1
     Flag2 = 2
     Flag3 = 4

--- a/src/it/resources/expected/my_record/cpp-headers/my_record.hpp
+++ b/src/it/resources/expected/my_record/cpp-headers/my_record.hpp
@@ -9,9 +9,11 @@
 #include <unordered_set>
 #include <utility>
 
+/** record comment */
 struct MyRecord final {
 
     static std::string const STRING_CONST;
+    /** record property comment */
     int32_t id;
     std::string info;
     std::unordered_set<std::string> store;

--- a/src/it/resources/expected/my_record/cppcli/MyRecord.hpp
+++ b/src/it/resources/expected/my_record/cppcli/MyRecord.hpp
@@ -5,6 +5,7 @@
 
 #include "../cpp-headers/my_record.hpp"
 
+/** record comment */
 [System::Serializable]
 public ref class MyRecord {
 public:
@@ -50,6 +51,7 @@ internal:
     static CsType FromCpp(const CppType& cpp);
 
 private:
+    /** record property comment */
     int _id;
     System::String^ _info;
     System::Collections::Generic::HashSet<System::String^>^ _store;

--- a/src/it/resources/expected/my_record/java/MyRecord.java
+++ b/src/it/resources/expected/my_record/java/MyRecord.java
@@ -6,6 +6,7 @@ package djinni.it;
 import java.util.HashMap;
 import java.util.HashSet;
 
+/** record comment */
 public final class MyRecord {
 
     public static final String STRING_CONST = "Constants can be put here";
@@ -30,6 +31,7 @@ public final class MyRecord {
         this.hash = hash;
     }
 
+    /** record property comment */
     public int getId() {
         return id;
     }

--- a/src/it/resources/expected/my_record/objc-headers/ITMyRecord.h
+++ b/src/it/resources/expected/my_record/objc-headers/ITMyRecord.h
@@ -3,6 +3,7 @@
 
 #import <Foundation/Foundation.h>
 
+/** record comment */
 @interface ITMyRecord : NSObject
 - (nonnull instancetype)initWithId:(int32_t)id
                               info:(nonnull NSString *)info
@@ -13,6 +14,7 @@
                                  store:(nonnull NSSet<NSString *> *)store
                                   hash:(nonnull NSDictionary<NSString *, NSNumber *> *)hash;
 
+/** record property comment */
 @property (nonatomic, readonly) int32_t id;
 
 @property (nonatomic, readonly, nonnull) NSString * info;

--- a/src/it/resources/expected/my_record/python/my_record.py
+++ b/src/it/resources/expected/my_record/python/my_record.py
@@ -14,6 +14,15 @@ from _cffi import ffi, lib
 from djinni import exception # this forces run of __init__.py which gives cpp option to call back into py to create exception
 
 class MyRecord:
+    """
+     record comment
+    Fields
+        id: record property comment
+        info
+        store
+        hash
+    """
+
     c_data_set = MultiSet()
 
     @staticmethod

--- a/src/it/resources/my_cpp_interface.djinni
+++ b/src/it/resources/my_cpp_interface.djinni
@@ -1,4 +1,6 @@
+# interface comment
 my_cpp_interface = interface +c {
+  # method comment
   method_returning_nothing(value: i32);
   method_returning_some_type(key: string): i32;
   const method_changing_nothing(): i32;

--- a/src/it/resources/my_enum.djinni
+++ b/src/it/resources/my_enum.djinni
@@ -1,4 +1,6 @@
+# enum comment
 my_enum = enum {
+  # enum option comment
   option1;
   option2;
   option3;

--- a/src/it/resources/my_flags.djinni
+++ b/src/it/resources/my_flags.djinni
@@ -1,4 +1,6 @@
+# flag comment
 my_flags = flags {
+  # flag option comment
   flag1;
   flag2;
   flag3;

--- a/src/it/resources/my_record.djinni
+++ b/src/it/resources/my_record.djinni
@@ -1,4 +1,6 @@
+# record comment
 my_record = record {
+  # record property comment
   id: i32;
   info: string;
   store: set<string>;

--- a/src/main/scala/djinni/CppCliGenerator.scala
+++ b/src/main/scala/djinni/CppCliGenerator.scala
@@ -357,11 +357,13 @@ class CppCliGenerator(spec: Spec) extends Generator(spec) {
     val methodNamesInScope = i.methods.map(m => idCs.method(m.ident))
 
     writeCppCliHppFile(ident, origin, refs.hpp, refs.hppFwds, w => {
+      writeDoc(w, doc)
       w.w(s"public ref class $self abstract").bracedSemi {
         w.wlOutdent("public:")
         val skipFirst = new SkipFirst
         i.methods.foreach(m => {
           skipFirst {w.wl}
+          writeDoc(w, m.doc)
           val staticVirtual = if (m.static) "static " else "virtual "
           val params = m.params.map(p => {
             marshal.paramType(p.ty, methodNamesInScope) + " " + idCs.local(p.ident)

--- a/src/main/scala/djinni/CppGenerator.scala
+++ b/src/main/scala/djinni/CppGenerator.scala
@@ -68,6 +68,7 @@ class CppGenerator(spec: Spec) extends Generator(spec) {
     val underlyingType = if(e.flags) flagsType else enumType
 
     writeHppFile(ident, origin, refs.hpp, refs.hppFwds, w => {
+      writeDoc(w, doc)
       w.w(s"enum class $self : $underlyingType").bracedSemi {
         writeEnumOptionNone(w, e, idCpp.enum)
         writeEnumOptions(w, e, idCpp.enum)


### PR DESCRIPTION
fixes #67 

Comments are now also copied to C++/CLI interfaces.
While adding comments to the integration-test IDL files to make sure everything works, I realized that enums/flags in C++ also missed some comments. This is also fixed by this PR.