### PR TITLE
fix extern djinni flags not being marshalled properly for JNI

### DIFF
--- a/src/main/scala/djinni/JNIMarshal.scala
+++ b/src/main/scala/djinni/JNIMarshal.scala
@@ -75,7 +75,10 @@ class JNIMarshal(spec: Spec) extends Marshal(spec) {
       case MSet => "Ljava/util/HashSet;"
       case MMap => "Ljava/util/HashMap;"
     }
-    case e: MExtern => e.jni.typeSignature.get
+    case e: MExtern => e.body match {
+      case e: Enum if e.flags => "Ljava/util/EnumSet;"
+      case _ => e.jni.typeSignature.get
+    }
     case MParam(_) => "Ljava/lang/Object;"
     case d: MDef => d.body match {
       case e: Enum if e.flags => "Ljava/util/EnumSet;"


### PR DESCRIPTION
In djinni, `flags` are declared as EnumSet in java.

Djinni generates files named `jni/NativeXXX.hpp` which are responsible
of resolving the library symbols by looking for function signatures and
map them to Java functions.

When a djinni type `flags` is declared in one module, and used in
another one (via `@extern` and yaml files), a function `foo` taking an
extern flags `my_flags` type as parameter would try to be resolved with:

const jmethodID method_statusesChanged{
  ::djinni::jniGetMethodID(clazz.get(), "foo", "(Lnz/co/abc/MyFlags;)V")};
 
This will thus fail to be resolved as the Java type for flags is
`EnumSet`, not the actual underlying enum type.

This commit fixes this by using an `EnumSet` properly for extern flags
resulting in the following:

const jmethodID method_statusesChanged{
  ::djinni::jniGetMethodID(clazz.get(), "foo", "(Ljava/util/EnumSet;)V")};