### PR TITLE
Allow externs to use an absolute path in addition to relative paths.

### DIFF
--- a/src/main/scala/djinni/parser.scala
+++ b/src/main/scala/djinni/parser.scala
@@ -51,8 +51,11 @@ private object IdlParser extends RegexParsers {
     var file: Option[File] = None
 
     val path = includePaths.find(path => {
-      val relPath = if (path.isEmpty) fileStack.top.getParent() else path
-      val tmp = new File(relPath, fileName)
+      var relPath = if (path.isEmpty) fileStack.top.getParent() else path
+      if (relPath.endsWith(fileName)) {
+        relPath = relPath.substring(0, relPath.length - fileName.length)
+      }
+      val tmp = if (relPath.isEmpty()) new File(fileName) else new File(relPath, fileName)
       val exists = tmp.exists
       if (exists) file = Some(tmp)
       exists


### PR DESCRIPTION
@extern should allow for absolute paths in addition to relative paths.  Some example usages that this patch permits to become usable:

```
@extern "path/directory/somewhere/else/extern_type.yaml"

# An interface that uses this type
my_interface = interface +c {
  # Do Something with that extern type.
  const do_something(extern_type: extern): bool;
}
```
