### PR TITLE
Restore support for --objc-base-lib-include-prefix.

### DIFF
--- a/src/main/scala/djinni/Main.scala
+++ b/src/main/scala/djinni/Main.scala
@@ -82,6 +82,7 @@ object Main {
     var objcppIncludeObjcPrefixOptional: Option[String] = None
     var objcFileIdentStyleOptional: Option[IdentConverter] = None
     var objcppNamespace: String = "djinni_generated"
+    var objcBaseLibIncludePrefix: String = ""
     var cppCliOutFolder: Option[File] = None
     var cppCliIdentStyle = IdentStyle.csDefault
     var cppCliNamespace: String = ""
@@ -220,6 +221,8 @@ object Main {
         .text("The prefix path for #import of the extended record Objective-C header (.h) files")
       opt[String]("objcpp-namespace").valueName("<prefix>").foreach(objcppNamespace = _)
         .text("The namespace name to use for generated Objective-C++ classes.")
+      opt[String]("objc-base-lib-include-prefix").valueName("<include-prefix>").foreach(objcBaseLibIncludePrefix = _)
+        .text("The Objective-C++ base library's include path, relative to the Objective-C++ classes. (default: \"djinni/objc/\")")
       note("\nPython")
       opt[File]("py-out").valueName("<out-folder>").foreach(x => pyOutFolder = Some(x))
         .text("The output folder for Python files (Generator disabled if unspecified).")
@@ -451,6 +454,7 @@ object Main {
       objcppIncludeCppPrefix,
       objcppIncludeObjcPrefix,
       objcppNamespace,
+      objcBaseLibIncludePrefix,
       objcSwiftBridgingHeaderWriter,
       cppCliOutFolder,
       cppCliIdentStyle,

--- a/src/main/scala/djinni/ObjcppMarshal.scala
+++ b/src/main/scala/djinni/ObjcppMarshal.scala
@@ -5,7 +5,7 @@ import djinni.generatorTools._
 import djinni.meta._
 
 class ObjcppMarshal(spec: Spec) extends Marshal(spec) {
-  final val objcBaseLibIncludePrefix = "djinni/objc/"
+  final val objcBaseLibIncludePrefix = spec.objcBaseLibIncludePrefix + "djinni/objc/"
 
   private val cppMarshal = new CppMarshal(spec)
   private val objcMarshal = new ObjcMarshal(spec)

--- a/src/main/scala/djinni/generator.scala
+++ b/src/main/scala/djinni/generator.scala
@@ -79,6 +79,7 @@ package object generatorTools {
                    objcppIncludeCppPrefix: String,
                    objcppIncludeObjcPrefix: String,
                    objcppNamespace: String,
+                   objcBaseLibIncludePrefix: String,
                    objcSwiftBridgingHeaderWriter: Option[Writer],
                    cppCliOutFolder: Option[File],
                    cppCliIdentStyle: CppCliIdentStyle,


### PR DESCRIPTION
--objc-base-lib-include-prefix was available in dropbox/djinni to allow for base-library files to be placed in different locations than default CMake install roots.  This is necessary for in source builds.