### PR TITLE
Use simplified method for converting types to/from json

### DIFF
--- a/src/it/resources/expected/all_datatypes_json/cpp-headers/all_datatypes_json+json.hpp
+++ b/src/it/resources/expected/all_datatypes_json/cpp-headers/all_datatypes_json+json.hpp
@@ -15,82 +15,73 @@
 #include <unordered_set>
 #include <vector>
 
-namespace nlohmann {
-
-template <>
-struct adl_serializer<::AllDatatypesJson>  {
-    static ::AllDatatypesJson from_json(const json & j)  {
-        auto result = ::AllDatatypesJson();
-        if (j.contains("booleanData")) {
-            j.at("booleanData").get_to(result.booleanData);
-        }
-        if (j.contains("integer8Data")) {
-            j.at("integer8Data").get_to(result.integer8Data);
-        }
-        if (j.contains("integer16Data")) {
-            j.at("integer16Data").get_to(result.integer16Data);
-        }
-        if (j.contains("integer32Data")) {
-            j.at("integer32Data").get_to(result.integer32Data);
-        }
-        if (j.contains("integer64Data")) {
-            j.at("integer64Data").get_to(result.integer64Data);
-        }
-        if (j.contains("float32Data")) {
-            j.at("float32Data").get_to(result.float32Data);
-        }
-        if (j.contains("float64Data")) {
-            j.at("float64Data").get_to(result.float64Data);
-        }
-        if (j.contains("stringData")) {
-            j.at("stringData").get_to(result.stringData);
-        }
-        if (j.contains("binaryData")) {
-            j.at("binaryData").get_to(result.binaryData);
-        }
-        if (j.contains("dateData")) {
-            j.at("dateData").get_to(result.dateData);
-        }
-        if (j.contains("listData")) {
-            j.at("listData").get_to(result.listData);
-        }
-        if (j.contains("setData")) {
-            j.at("setData").get_to(result.setData);
-        }
-        if (j.contains("mapData")) {
-            j.at("mapData").get_to(result.mapData);
-        }
-        if (j.contains("optionalData")) {
-            j.at("optionalData").get_to(result.optionalData);
-        }
-        if (j.contains("enum_data")) {
-            j.at("enum_data").get_to(result.enum_data);
-        }
-        if (j.contains("myFlags")) {
-            j.at("myFlags").get_to(result.myFlags);
-        }
-        return result;
+static void from_json(const nlohmann::json & j, all_datatypes_json& result)  {
+    if (j.contains("booleanData")) {
+        j.at("booleanData").get_to(result.booleanData);
     }
-    static void to_json(json & j, const ::AllDatatypesJson & item)  {
-        j = json {
-            {"booleanData", item.booleanData},
-            {"integer8Data", item.integer8Data},
-            {"integer16Data", item.integer16Data},
-            {"integer32Data", item.integer32Data},
-            {"integer64Data", item.integer64Data},
-            {"float32Data", item.float32Data},
-            {"float64Data", item.float64Data},
-            {"stringData", item.stringData},
-            {"binaryData", item.binaryData},
-            {"dateData", item.dateData},
-            {"listData", item.listData},
-            {"setData", item.setData},
-            {"mapData", item.mapData},
-            {"optionalData", item.optionalData},
-            {"enum_data", item.enum_data},
-            {"myFlags", item.myFlags}
-        };
+    if (j.contains("integer8Data")) {
+        j.at("integer8Data").get_to(result.integer8Data);
     }
-};
-
-}  // namespace nlohmann
+    if (j.contains("integer16Data")) {
+        j.at("integer16Data").get_to(result.integer16Data);
+    }
+    if (j.contains("integer32Data")) {
+        j.at("integer32Data").get_to(result.integer32Data);
+    }
+    if (j.contains("integer64Data")) {
+        j.at("integer64Data").get_to(result.integer64Data);
+    }
+    if (j.contains("float32Data")) {
+        j.at("float32Data").get_to(result.float32Data);
+    }
+    if (j.contains("float64Data")) {
+        j.at("float64Data").get_to(result.float64Data);
+    }
+    if (j.contains("stringData")) {
+        j.at("stringData").get_to(result.stringData);
+    }
+    if (j.contains("binaryData")) {
+        j.at("binaryData").get_to(result.binaryData);
+    }
+    if (j.contains("dateData")) {
+        j.at("dateData").get_to(result.dateData);
+    }
+    if (j.contains("listData")) {
+        j.at("listData").get_to(result.listData);
+    }
+    if (j.contains("setData")) {
+        j.at("setData").get_to(result.setData);
+    }
+    if (j.contains("mapData")) {
+        j.at("mapData").get_to(result.mapData);
+    }
+    if (j.contains("optionalData")) {
+        j.at("optionalData").get_to(result.optionalData);
+    }
+    if (j.contains("enum_data")) {
+        j.at("enum_data").get_to(result.enum_data);
+    }
+    if (j.contains("myFlags")) {
+        j.at("myFlags").get_to(result.myFlags);
+    }
+}
+static void to_json(nlohmann::json & j, const all_datatypes_json & item)  {
+    j = nlohmann::json {
+        {"booleanData", item.booleanData},
+        {"integer8Data", item.integer8Data},
+        {"integer16Data", item.integer16Data},
+        {"integer32Data", item.integer32Data},
+        {"integer64Data", item.integer64Data},
+        {"float32Data", item.float32Data},
+        {"float64Data", item.float64Data},
+        {"stringData", item.stringData},
+        {"binaryData", item.binaryData},
+        {"dateData", item.dateData},
+        {"listData", item.listData},
+        {"setData", item.setData},
+        {"mapData", item.mapData},
+        {"optionalData", item.optionalData},
+        {"enum_data", item.enum_data},
+        {"myFlags", item.myFlags}
+    };
+}

--- a/src/it/resources/expected/all_datatypes_json/cpp-headers/enum_data+json.hpp
+++ b/src/it/resources/expected/all_datatypes_json/cpp-headers/enum_data+json.hpp
@@ -8,31 +8,23 @@
 #include <algorithm>
 #include <nlohmann/json.hpp>
 
-namespace nlohmann {
-
-template<>
-struct adl_serializer<::EnumData>
+static void to_json(nlohmann::json& j, enum_data e)
 {
-    static void to_json(json& j, ::EnumData e)
+    static const std::pair<enum_data, nlohmann::json> m[] = {{enum_data::FIRSTENUMVALUE,"FirstEnumValue"},{enum_data::SECONDENUMVALUE,"SecondEnumValue"}};
+    auto it = std::find_if(std::begin(m), std::end(m),
+                           [e](const std::pair<enum_data, nlohmann::json>& ej_pair) -> bool
     {
-        static const std::pair<::EnumData, json> m[] = {{::EnumData::FIRSTENUMVALUE,"FirstEnumValue"},{::EnumData::SECONDENUMVALUE,"SecondEnumValue"}};
-        auto it = std::find_if(std::begin(m), std::end(m),
-                               [e](const std::pair<::EnumData, json>& ej_pair) -> bool
-        {
-            return ej_pair.first == e;
-        });
-        j = ((it != std::end(m)) ? it : std::begin(m))->second;
-    }
-    static void from_json(const json& j, ::EnumData& e)
+        return ej_pair.first == e;
+    });
+    j = ((it != std::end(m)) ? it : std::begin(m))->second;
+}
+static void from_json(const nlohmann::json& j, enum_data& e)
+{
+    static const std::pair<enum_data, nlohmann::json> m[] = {{enum_data::FIRSTENUMVALUE,"FirstEnumValue"},{enum_data::SECONDENUMVALUE,"SecondEnumValue"}};
+    auto it = std::find_if(std::begin(m), std::end(m),
+                           [j](const std::pair<enum_data, nlohmann::json>& ej_pair) -> bool
     {
-        static const std::pair<::EnumData, json> m[] = {{::EnumData::FIRSTENUMVALUE,"FirstEnumValue"},{::EnumData::SECONDENUMVALUE,"SecondEnumValue"}};
-        auto it = std::find_if(std::begin(m), std::end(m),
-                               [j](const std::pair<::EnumData, json>& ej_pair) -> bool
-        {
-            return ej_pair.second == j;
-        });
-        e = ((it != std::end(m)) ? it : std::begin(m))->first;
-    }
-};
-
-}  // namespace nlohmann
+        return ej_pair.second == j;
+    });
+    e = ((it != std::end(m)) ? it : std::begin(m))->first;
+}

--- a/src/it/resources/expected/all_datatypes_json/cpp-headers/my_flags+json.hpp
+++ b/src/it/resources/expected/all_datatypes_json/cpp-headers/my_flags+json.hpp
@@ -8,40 +8,32 @@
 #include <algorithm>
 #include <nlohmann/json.hpp>
 
-namespace nlohmann {
-
-template<>
-struct adl_serializer<::MyFlags>
+static void to_json(nlohmann::json& j, my_flags e)
 {
-    static void to_json(json& j, ::MyFlags e)
+    static const std::pair<my_flags, nlohmann::json> m[] = {{my_flags::FLAG1,"flag1"},{my_flags::FLAG2,"flag2"},{my_flags::FLAG3,"flag3"}};
+    j = nlohmann::json::array();
+    for(const auto& flagOption : m)
     {
-        static const std::pair<::MyFlags, json> m[] = {{::MyFlags::FLAG1,"flag1"},{::MyFlags::FLAG2,"flag2"},{::MyFlags::FLAG3,"flag3"}};
-        j = json::array();
-        for(const auto& flagOption : m)
+        if(static_cast<unsigned>(e & flagOption.first) != 0)
         {
-            if(static_cast<unsigned>(e & flagOption.first) != 0)
-            {
-                j.push_back(flagOption.second);
-            }
+            j.push_back(flagOption.second);
         }
     }
-    static void from_json(const json& j, ::MyFlags& e)
+}
+static void from_json(const nlohmann::json& j, my_flags& e)
+{
+    static const std::pair<my_flags, nlohmann::json> m[] = {{my_flags::FLAG1,"flag1"},{my_flags::FLAG2,"flag2"},{my_flags::FLAG3,"flag3"}};
+    e = static_cast<my_flags>(0);
+    for(const auto& flagName : j)
     {
-        static const std::pair<::MyFlags, json> m[] = {{::MyFlags::FLAG1,"flag1"},{::MyFlags::FLAG2,"flag2"},{::MyFlags::FLAG3,"flag3"}};
-        e = static_cast<::MyFlags>(0);
-        for(const auto& flagName : j)
+        auto it = std::find_if(std::begin(m), std::end(m),
+                               [flagName](const std::pair<my_flags, nlohmann::json>& ej_pair) -> bool
         {
-            auto it = std::find_if(std::begin(m), std::end(m),
-                                   [flagName](const std::pair<::MyFlags, json>& ej_pair) -> bool
-            {
-                return ej_pair.second == flagName;
-            });
-            if(it != std::end(m))
-            {
-                e |= it->first;
-            }
+            return ej_pair.second == flagName;
+        });
+        if(it != std::end(m))
+        {
+            e |= it->first;
         }
     }
-};
-
-}  // namespace nlohmann
+}

--- a/src/it/resources/expected/all_json_specialized_datatypes_in_custom_namespace/cpp-headers/my_enum+json.hpp
+++ b/src/it/resources/expected/all_json_specialized_datatypes_in_custom_namespace/cpp-headers/my_enum+json.hpp
@@ -8,31 +8,27 @@
 #include <algorithm>
 #include <nlohmann/json.hpp>
 
-namespace nlohmann {
+namespace custom_namespace {
 
-template<>
-struct adl_serializer<::custom_namespace::MyEnum>
+static void to_json(nlohmann::json& j, my_enum e)
 {
-    static void to_json(json& j, ::custom_namespace::MyEnum e)
+    static const std::pair<my_enum, nlohmann::json> m[] = {{my_enum::FIRSTENUMVALUE,"FirstEnumValue"},{my_enum::SECONDENUMVALUE,"SecondEnumValue"}};
+    auto it = std::find_if(std::begin(m), std::end(m),
+                           [e](const std::pair<my_enum, nlohmann::json>& ej_pair) -> bool
     {
-        static const std::pair<::custom_namespace::MyEnum, json> m[] = {{::custom_namespace::MyEnum::FIRSTENUMVALUE,"FirstEnumValue"},{::custom_namespace::MyEnum::SECONDENUMVALUE,"SecondEnumValue"}};
-        auto it = std::find_if(std::begin(m), std::end(m),
-                               [e](const std::pair<::custom_namespace::MyEnum, json>& ej_pair) -> bool
-        {
-            return ej_pair.first == e;
-        });
-        j = ((it != std::end(m)) ? it : std::begin(m))->second;
-    }
-    static void from_json(const json& j, ::custom_namespace::MyEnum& e)
+        return ej_pair.first == e;
+    });
+    j = ((it != std::end(m)) ? it : std::begin(m))->second;
+}
+static void from_json(const nlohmann::json& j, my_enum& e)
+{
+    static const std::pair<my_enum, nlohmann::json> m[] = {{my_enum::FIRSTENUMVALUE,"FirstEnumValue"},{my_enum::SECONDENUMVALUE,"SecondEnumValue"}};
+    auto it = std::find_if(std::begin(m), std::end(m),
+                           [j](const std::pair<my_enum, nlohmann::json>& ej_pair) -> bool
     {
-        static const std::pair<::custom_namespace::MyEnum, json> m[] = {{::custom_namespace::MyEnum::FIRSTENUMVALUE,"FirstEnumValue"},{::custom_namespace::MyEnum::SECONDENUMVALUE,"SecondEnumValue"}};
-        auto it = std::find_if(std::begin(m), std::end(m),
-                               [j](const std::pair<::custom_namespace::MyEnum, json>& ej_pair) -> bool
-        {
-            return ej_pair.second == j;
-        });
-        e = ((it != std::end(m)) ? it : std::begin(m))->first;
-    }
-};
+        return ej_pair.second == j;
+    });
+    e = ((it != std::end(m)) ? it : std::begin(m))->first;
+}
 
-}  // namespace nlohmann
+}  // namespace custom_namespace

--- a/src/it/resources/expected/all_json_specialized_datatypes_in_custom_namespace/cpp-headers/my_flags+json.hpp
+++ b/src/it/resources/expected/all_json_specialized_datatypes_in_custom_namespace/cpp-headers/my_flags+json.hpp
@@ -8,40 +8,36 @@
 #include <algorithm>
 #include <nlohmann/json.hpp>
 
-namespace nlohmann {
+namespace custom_namespace {
 
-template<>
-struct adl_serializer<::custom_namespace::MyFlags>
+static void to_json(nlohmann::json& j, my_flags e)
 {
-    static void to_json(json& j, ::custom_namespace::MyFlags e)
+    static const std::pair<my_flags, nlohmann::json> m[] = {{my_flags::FLAG1,"flag1"},{my_flags::FLAG2,"flag2"}};
+    j = nlohmann::json::array();
+    for(const auto& flagOption : m)
     {
-        static const std::pair<::custom_namespace::MyFlags, json> m[] = {{::custom_namespace::MyFlags::FLAG1,"flag1"},{::custom_namespace::MyFlags::FLAG2,"flag2"}};
-        j = json::array();
-        for(const auto& flagOption : m)
+        if(static_cast<unsigned>(e & flagOption.first) != 0)
         {
-            if(static_cast<unsigned>(e & flagOption.first) != 0)
-            {
-                j.push_back(flagOption.second);
-            }
+            j.push_back(flagOption.second);
         }
     }
-    static void from_json(const json& j, ::custom_namespace::MyFlags& e)
+}
+static void from_json(const nlohmann::json& j, my_flags& e)
+{
+    static const std::pair<my_flags, nlohmann::json> m[] = {{my_flags::FLAG1,"flag1"},{my_flags::FLAG2,"flag2"}};
+    e = static_cast<my_flags>(0);
+    for(const auto& flagName : j)
     {
-        static const std::pair<::custom_namespace::MyFlags, json> m[] = {{::custom_namespace::MyFlags::FLAG1,"flag1"},{::custom_namespace::MyFlags::FLAG2,"flag2"}};
-        e = static_cast<::custom_namespace::MyFlags>(0);
-        for(const auto& flagName : j)
+        auto it = std::find_if(std::begin(m), std::end(m),
+                               [flagName](const std::pair<my_flags, nlohmann::json>& ej_pair) -> bool
         {
-            auto it = std::find_if(std::begin(m), std::end(m),
-                                   [flagName](const std::pair<::custom_namespace::MyFlags, json>& ej_pair) -> bool
-            {
-                return ej_pair.second == flagName;
-            });
-            if(it != std::end(m))
-            {
-                e |= it->first;
-            }
+            return ej_pair.second == flagName;
+        });
+        if(it != std::end(m))
+        {
+            e |= it->first;
         }
     }
-};
+}
 
-}  // namespace nlohmann
+}  // namespace custom_namespace

--- a/src/it/resources/expected/all_json_specialized_datatypes_in_custom_namespace/cpp-headers/my_record+json.hpp
+++ b/src/it/resources/expected/all_json_specialized_datatypes_in_custom_namespace/cpp-headers/my_record+json.hpp
@@ -8,26 +8,21 @@
 #include "my_flags+json.hpp"
 #include <nlohmann/json.hpp>
 
-namespace nlohmann {
+namespace custom_namespace {
 
-template <>
-struct adl_serializer<::custom_namespace::MyRecord>  {
-    static ::custom_namespace::MyRecord from_json(const json & j)  {
-        auto result = ::custom_namespace::MyRecord();
-        if (j.contains("myEnum")) {
-            j.at("myEnum").get_to(result.myEnum);
-        }
-        if (j.contains("myFlags")) {
-            j.at("myFlags").get_to(result.myFlags);
-        }
-        return result;
+static void from_json(const nlohmann::json & j, my_record& result)  {
+    if (j.contains("myEnum")) {
+        j.at("myEnum").get_to(result.myEnum);
     }
-    static void to_json(json & j, const ::custom_namespace::MyRecord & item)  {
-        j = json {
-            {"myEnum", item.myEnum},
-            {"myFlags", item.myFlags}
-        };
+    if (j.contains("myFlags")) {
+        j.at("myFlags").get_to(result.myFlags);
     }
-};
+}
+static void to_json(nlohmann::json & j, const my_record & item)  {
+    j = nlohmann::json {
+        {"myEnum", item.myEnum},
+        {"myFlags", item.myFlags}
+    };
+}
 
-}  // namespace nlohmann
+}  // namespace custom_namespace


### PR DESCRIPTION
The basic recommended method for converting to/from json is described here: https://json.nlohmann.me/features/arbitrary_types/#basic-usage

```
namespace ns {
    void to_json(json& j, const person& p) {
        j = json{ {"name", p.name}, {"address", p.address}, {"age", p.age} };
    }

    void from_json(const json& j, person& p) {
        j.at("name").get_to(p.name);
        j.at("address").get_to(p.address);
        j.at("age").get_to(p.age);
    }
} // namespace ns
```

Where `ns` is the type's namespace.
 
The current implementation in djinni is using the method recommended for third-party types such as e.g. in std where we cannot place our implementation into the type's namespace.

When there are errors, however, it is much harder to understand what's wrong -and I've recently run into problems trying to convert types which have been defined in multiple libraries.