### PR TITLE
CD deploy main branch, initial step

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -59,10 +59,10 @@ jobs:
       - name: Running integration-tests
         run: sbt IntegrationTest/test
 
-  draftNextRelease:
+  publishPreRelease:
     runs-on: ubuntu-latest
     needs: [it]
-    if: github.ref == 'refs/heads/cd-deploy'
+    if: github.ref == 'refs/heads/main'
     steps:
       - uses: actions/download-artifact@v2
         with:

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -71,7 +71,6 @@ jobs:
       - name: Restoring file permissions of artifact
         run: chmod u+x target/bin/djinni
       - uses: "marvinpinto/action-automatic-releases@latest"
-      - name: "Create current-latest pre-release"
         with:
           title: "Latest development build"
           repo_token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -59,3 +59,24 @@ jobs:
       - name: Running integration-tests
         run: sbt IntegrationTest/test
 
+  draftNextRelease:
+    runs-on: ubuntu-latest
+    needs: [it]
+    if: github.ref == 'refs/heads/cd-deploy'
+    steps:
+      - uses: actions/download-artifact@v2
+        with:
+          name: djinni-generator
+          path: target/bin
+      - name: Restoring file permissions of artifact
+        run: chmod u+x target/bin/djinni
+      - uses: "marvinpinto/action-automatic-releases@latest"
+      - name: "Create current-latest pre-release"
+        with:
+          title: "Latest development build"
+          repo_token: "${{ secrets.GITHUB_TOKEN }}"
+          prerelease: true
+          automatic_release_tag: current-latest
+          files: |
+            target/bin/djinni
+

--- a/src/main/scala/djinni/Main.scala
+++ b/src/main/scala/djinni/Main.scala
@@ -130,7 +130,7 @@ object Main {
 
       override def showUsageOnError = Some(false)
       head(
-        "djinni generator version",
+        "djinni generator version:",
         Main.getClass.getPackage.getImplementationVersion
       )
       note("General")

--- a/src/main/scala/djinni/Main.scala
+++ b/src/main/scala/djinni/Main.scala
@@ -130,7 +130,7 @@ object Main {
 
       override def showUsageOnError = Some(false)
       head(
-        "djinni generator version:",
+        "djinni generator version",
         Main.getClass.getPackage.getImplementationVersion
       )
       note("General")


### PR DESCRIPTION
Each successful commit to master uploads a djinni binary as a pre-release release.
Any existing pre-release release will be replaced.

That should be the first step to solving the issue discussed in #94 

With this change, no release is needed anymore.
A simple `curl -LJO https://github.com/https://github.com/cross-language-cpp/djinni-generator/releases/download/current-latest/djinni` will give the latest djinni build. 

The usage of that needs, of course, to be implemented in the support-lib CI.

More variations of the topic are possible, e.g., pre-releasing branches under a special name, and if support lib knows that name it does not even have to wait for a merge to main.
