### PR TITLE
Adding a stale bot for ticket hygiene.

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,17 @@
+# Number of days of inactivity before an issue becomes stale
+daysUntilStale: 60
+# Number of days of inactivity before a stale issue is closed
+daysUntilClose: 7
+# Issues with these labels will never be considered stale
+exemptLabels:
+  - idea
+
+# Label to use when marking an issue as stale
+staleLabel: stale
+# Comment to post when marking an issue as stale. Set to `false` to disable
+markComment: >
+  This issue has been automatically marked as stale because it has not had
+  recent activity. It will be closed if no further activity occurs. Thank you
+  for your contributions.
+# Comment to post when closing a stale issue. Set to `false` to disable
+closeComment: false


### PR DESCRIPTION
I do not believe having issues and PRs open forever is a good practice
But my manual intervention was not always appreciated since it could be seen as a personal action against an activity.

Therefore, I added the [stale application](https://github.com/marketplace/stale) to cross-langauage-cpp. 
With it, we have a democratic robot that threads all issues and PRs equally by definition, and personal feelings against a person doing the ticket hygiene will be avoided. 

After 60 days of inactivity, a message is triggered
After 7 additional days, the issue or PR gets closed, 

Closed items can be reopened if ever needed.
Auto-closed issues and PRs get the label `stale` so we can review staled items if needed.
Exceptions: If a ticket / PR has the label idea, it will not be handled by this bot.

This PR activates the stale bot for the generator repository.