### PR TITLE
Prevent methods renaming in Swift

### DIFF
--- a/src/main/scala/djinni/Main.scala
+++ b/src/main/scala/djinni/Main.scala
@@ -87,6 +87,7 @@ object Main {
     var objcppIncludeObjcPrefixOptional: Option[String] = None
     var objcFileIdentStyleOptional: Option[IdentConverter] = None
     var objcStrictProtocol: Boolean = true
+    var objcPreventObjcFunctionRenameInSwift: Boolean = false
     var objcppNamespace: String = "djinni_generated"
     var cppCliOutFolder: Option[File] = None
     var cppCliIdentStyle = IdentStyle.csDefault
@@ -381,6 +382,12 @@ object Main {
         .foreach(x => objcStrictProtocol = x)
         .text(
           "All generated @protocol will implement <NSObject> (default: true). "
+        )
+      opt[Boolean](name = "objc-prevent-objc-function-rename-in-swift")
+        .valueName("<true/false>")
+        .foreach(x => objcPreventObjcFunctionRenameInSwift = x)
+        .text(
+          "All generated methods with parameters in @interface will use NS_SWIFT_NAME macro to prevent renaming in SWIFT (default: false)"
         )
 
       note("\nObjective-C++")
@@ -924,6 +931,7 @@ object Main {
       objcSwiftBridgingHeaderName,
       objcClosedEnums,
       objcStrictProtocol,
+      objcPreventObjcFunctionRenameInSwift,
       outFileListWriter,
       skipGeneration,
       yamlOutFolder,

--- a/src/main/scala/djinni/ObjcGenerator.scala
+++ b/src/main/scala/djinni/ObjcGenerator.scala
@@ -105,6 +105,21 @@ class ObjcGenerator(spec: Spec) extends BaseObjcGenerator(spec) {
 
     refs.header.add("#import <Foundation/Foundation.h>")
 
+    def getLocalIdentifiers(parameters: Seq[Field]): Seq[String] = {
+      parameters.map(item => {
+        idObjc.local(item.ident)
+      })
+    }
+
+    def appendNSSwiftName(call: String, parameters: Seq[Field], w: IndentWriter): Unit = {
+      val identifiers : Seq[String] = getLocalIdentifiers(parameters)
+      if (identifiers.nonEmpty){
+        val concatenatedString = s"    NS_SWIFT_NAME(${call}(${identifiers.mkString("", ":", ":")}))"
+        w.wl
+        w.w(concatenatedString)
+      }
+    }
+
     def writeObjcFuncDecl(method: Interface.Method, w: IndentWriter) {
       val label = if (method.static) "+" else "-"
       val ret = marshal.returnType(method.ret)
@@ -120,6 +135,7 @@ class ObjcGenerator(spec: Spec) extends BaseObjcGenerator(spec) {
             s"(${marshal.paramType(p.ty)})${idObjc.local(p.ident)}"
           )
       )
+      if (spec.objcPreventObjcFunctionRenameInSwift) appendNSSwiftName(idObjc.method(method.ident), method.params, w)
     }
 
     // Generate the header file for Interface

--- a/src/main/scala/djinni/generator.scala
+++ b/src/main/scala/djinni/generator.scala
@@ -87,6 +87,7 @@ package object generatorTools {
       objcSwiftBridgingHeaderName: Option[String],
       objcClosedEnums: Boolean,
       objcStrictProtocol: Boolean,
+      objcPreventObjcFunctionRenameInSwift: Boolean,
       outFileListWriter: Option[Writer],
       skipGeneration: Boolean,
       yamlOutFolder: Option[File],


### PR DESCRIPTION
If I'm using generated code in Swift project, then Swift will rename my methods into something else (they have some naming rules). That, basically brakes all thing: API then looking totally different. There is a macro `NS_SWIFT_NAME`, where you can put a name, which Swift will use (something like "I know what I'm doing. Please, Swift, leave method name as it is written in macro."). So, there is an option for that: to add or not to add this macro to every method of generated API.

Some more context about this Swift feature:
- https://developer.apple.com/documentation/swift/renaming-objective-c-apis-for-swift
- https://github.com/apple/swift-evolution/blob/main/proposals/0005-objective-c-name-translation.md
- https://github.com/apple/swift/blob/main/docs/CToSwiftNameTranslation.md
- https://github.com/apple/swift/blob/main/docs/CToSwiftNameTranslation-OmitNeedlessWords.md
